### PR TITLE
chore(gitignore): remove blanket Cargo.toml ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,7 +190,6 @@ tests/conftest.py
 REPOS_INDEX.md
 SESSION_GAPS_2026_03_29.md
 audit_worktrees.sh
-Cargo.toml
 EXTRACTION_REPORT_CONFIG_CORE.md
 docs/CI-CD-IMPLEMENTATION-SUMMARY.md
 docs/reference/GAP_SWEEP_INDEX.md


### PR DESCRIPTION
## Summary

Removes the bare `Cargo.toml` line from `.gitignore` so per-crate manifests can be committed without `git add -f`.

Blanket `.gitignore` rule silently hid per-crate `Cargo.toml` files during workspace extraction, causing phantom member drift (workspace members referenced in root `Cargo.toml` but missing on disk).

Per `worklogs/GOVERNANCE.md` anti-pattern audit (task #105, 2026-04-24). PRs #68 and #69 already restored the stack here; this is the gitignore hygiene follow-up.

## Scope

This PR ONLY fixes `.gitignore`. Restoring phantom crate manifests is follow-up work.

## Test plan

- [x] `grep -n '^Cargo\.toml$' .gitignore` returns nothing after change
- [ ] Per-crate `Cargo.toml` files can now be added without `-f`

Refs: #105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to stop hiding Rust `Cargo.toml` files, with no runtime or production code changes.
> 
> **Overview**
> Removes the blanket `Cargo.toml` ignore rule from `.gitignore` so per-crate Rust manifests can be added/committed normally (without `git add -f`) and don’t get silently excluded during workspace extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a22cc394fa10ad6002546bda84e3e883a681fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->