### PR TITLE
ci(legacy-tooling-gate): adopt phenoShared reusable

### DIFF
--- a/.github/workflows/legacy-tooling-gate.yml
+++ b/.github/workflows/legacy-tooling-gate.yml
@@ -1,5 +1,8 @@
 name: Legacy Tooling Gate (WARN Mode)
 
+# Thin caller — delegates to the shared reusable workflow in phenoShared.
+# See KooshaPari/phenoShared#85 / audit #182 for rationale (14-repo dedup).
+
 on:
   push:
     branches: [main, master, develop]
@@ -9,94 +12,8 @@ on:
 
 jobs:
   legacy-tooling-scan:
-    name: Legacy Tooling Anti-Pattern Scan
-    runs-on: ubuntu-latest
+    uses: KooshaPari/phenoShared/.github/workflows/reusable/legacy-tooling-gate.yml@393519642656b8f6a2f459c22e0983a4725b7acb
     permissions:
       contents: read
       security-events: write
       pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Checkout phenotype/repos for shared tools
-        uses: actions/checkout@v4
-        with:
-          repository: kooshapari/phenotype
-          path: phenotype-repos
-          sparse-checkout: tooling/legacy-enforcement
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install pyyaml
-
-      - name: Run Legacy Tooling Scanner (WARN Mode)
-        run: |
-          python3 phenotype-repos/tooling/legacy-enforcement/scanner/legacy_tooling_scanner.py \
-            --repo-root . \
-            --policy phenotype-repos/tooling/legacy-enforcement/policy/rules.yaml \
-            --output-json legacy_tooling_report.json \
-            --output-md legacy_tooling_report.md \
-            --report-only
-        continue-on-error: true
-
-      - name: Upload scan report (JSON)
-        uses: actions/upload-artifact@v4
-        with:
-          name: legacy-tooling-report-json
-          path: legacy_tooling_report.json
-          retention-days: 30
-
-      - name: Upload scan report (Markdown)
-        uses: actions/upload-artifact@v4
-        with:
-          name: legacy-tooling-report-md
-          path: legacy_tooling_report.md
-          retention-days: 30
-
-      - name: Comment PR with findings
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            let report = '**Legacy Tooling Scan Report**\n\n';
-            
-            try {
-              const data = JSON.parse(fs.readFileSync('legacy_tooling_report.json', 'utf8'));
-              const totals = data.totals || {};
-              
-              report += `| Severity | Count |\n|----------|-------|\n`;
-              report += `| Critical | ${totals.critical || 0} |\n`;
-              report += `| High | ${totals.high || 0} |\n`;
-              report += `| Medium | ${totals.medium || 0} |\n`;
-              report += `| Low | ${totals.low || 0} |\n\n`;
-              
-              const findings = data.findings || [];
-              if (findings.length > 0) {
-                report += '**Top Violations:**\n';
-                findings.slice(0, 5).forEach(f => {
-                  report += `- [${f.severity.toUpperCase()}] ${f.rule_id}: ${f.file}:${f.line}\n`;
-                });
-                if (findings.length > 5) {
-                  report += `- ... and ${findings.length - 5} more\n`;
-                }
-              } else {
-                report += 'No violations detected.\n';
-              }
-              
-              report += '\n*This is a WARN-mode scan. Fix before strict enforcement begins.*';
-            } catch (e) {
-              report += 'Could not parse scan results.';
-            }
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: report
-            });


### PR DESCRIPTION
## **User description**
## Summary

Replaces the local 102-line `legacy-tooling-gate.yml` with a 19-line caller that delegates to the new shared reusable workflow in `KooshaPari/phenoShared`:

`KooshaPari/phenoShared/.github/workflows/reusable/legacy-tooling-gate.yml@393519642656b8f6a2f459c22e0983a4725b7acb`

Part of audit #182 — 14-repo dedup of the legacy tooling gate.

## Prerequisite

**Merge order:** phenoShared#85 must merge to `main` first (pinned SHA is on that PR's branch). If phenoShared#85 merges under a different SHA, re-pin this caller before merging.

## LOC delta

- Removed: 87 lines
- Added: 4 lines
- Net: **-83 LOC**

## Test plan

- [ ] Verify push / pull_request triggers fire the caller workflow
- [ ] Verify reusable workflow resolves (requires phenoShared#85 merged)
- [ ] Confirm scan report artifacts upload with same names
- [ ] Confirm PR comment job still posts on PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior now depends on an external reusable workflow pinned to a specific SHA, so failures or mismatched expectations could silently change scan/reporting behavior across repos. Scope is limited to GitHub Actions configuration (no production code).
> 
> **Overview**
> Switches `.github/workflows/legacy-tooling-gate.yml` from an inlined, step-by-step legacy tooling scan (checkout + Python run + artifact uploads + PR comment) to a **thin caller** that invokes `KooshaPari/phenoShared/.github/workflows/reusable/legacy-tooling-gate.yml` pinned to a specific SHA.
> 
> Keeps the same triggers and job-level permissions, but centralizes the scan implementation in the shared workflow for cross-repo deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e5730ee942f1067ea63ce8c21b74ac92776fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Move the legacy tooling gate to a shared reusable workflow**

### What Changed
- The legacy tooling scan now runs through a shared workflow from `phenoShared` instead of a repo-local copy
- The workflow keeps the same triggers and permissions, so push and pull request checks still run in the same places
- Scan results and PR comments are now handled by the shared workflow

### Impact
`✅ Consistent legacy tooling checks across repos`
`✅ Less duplicated CI configuration`
`✅ Easier updates to the legacy tooling gate`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Yr7mLhA6tAiuyMY2UCVqs7_dyg5PbFFuWkiMWhqvL0U&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
