### PR TITLE
ci(codeql): switch to reusable phenoShared workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,21 +4,17 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
   schedule:
-    - cron: '0 12 * * 1'
+    - cron: '17 4 * * 1'
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    uses: KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce629168f0e1ec3699706cb73d1f77cb751
     permissions:
+      contents: read
+      actions: read
       security-events: write
-    strategy:
-      matrix:
-        language: [rust]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+    with:
+      languages: '["rust"]'
+      build-mode: 'autobuild'


### PR DESCRIPTION
## **User description**
Swaps per-repo CodeQL workflow for a thin caller to `KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce629168f0e1ec3699706cb73d1f77cb751`.

Inputs: languages=`["rust"]`, build-mode=`autobuild`.

Depends on phenoShared#87. Caller is pinned to commit SHA; rebase after phenoShared#87 merges to point at main.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because security scanning is delegated to an external reusable workflow; behavior now depends on the pinned `phenoShared` implementation and updated schedule/permissions.
> 
> **Overview**
> Switches the `CodeQL` GitHub Actions workflow from an in-repo job definition to a thin caller that `uses` the pinned `KooshaPari/phenoShared` reusable CodeQL workflow.
> 
> Updates triggers (adds `pull_request` branch filter and changes the weekly cron time) and passes explicit inputs (`languages: ["rust"]`, `build-mode: autobuild`) along with tightened job permissions (`contents`/`actions` read, `security-events` write).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 389e55b5e2294d4d395e0578ee1b953fa8cd3820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Run CodeQL through the shared workflow with Rust autobuild

### What Changed
- CodeQL now uses the shared reusable workflow instead of a repo-specific scan job
- The scan is configured for Rust with autobuild, matching the previous analysis setup
- Pull request scans are limited to the main branch, and the weekly run time has changed
- The workflow now requests only the permissions needed for scanning results

### Impact
`✅ Consistent CodeQL scans across repos`
`✅ Fewer security scan setup issues`
`✅ Clearer PR and scheduled scan behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=7cNFEo4WP2xK5MtF8mo71PdI__Q2tkUiowLEWKKtM5g&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
