### PR TITLE
chore(workflows): delegate tag-automation to phenoShared reusable

### DIFF
--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -1,78 +1,15 @@
 name: Tag Automation
+
+# Delegates to phenoShared reusable workflow.
+# See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/reusable/tag-automation.yml
+
 on:
   push:
     tags:
       - 'v*'
+
 jobs:
   tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-<<<<<<< HEAD
-      - name: Create release tag
-        run: echo "Creating release for ${{ github.ref_name }}"
-=======
-<<<<<<< HEAD
-      - name: Create release tag
-        run: echo "Creating release for ${{ github.ref_name }}"
-=======
-        with:
-          fetch-depth: 0
-
-      - name: Extract version from Cargo.toml
-        id: version
-        run: |
-          VERSION=$(grep -A 5 '\[workspace.package\]' Cargo.toml | grep '^version' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          if [ -z "$VERSION" ]; then
-            echo "ERROR: Could not extract version from Cargo.toml" >&2
-            exit 1
-          fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Extracted version: ${VERSION}"
-
-      - name: Validate version format
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: Invalid version format: $VERSION" >&2
-            exit 1
-          fi
-          echo "Version format validated: $VERSION"
-
-      - name: Check if tag exists
-        id: check_tag
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          TAG="v${VERSION}"
-          if git rev-parse "$TAG" > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag $TAG already exists, skipping creation"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Tag $TAG does not exist, will create"
-          fi
-
-      - name: Create and push tag
-        if: steps.check_tag.outputs.exists == 'false'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          TAG="v${VERSION}"
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-          echo "Created and pushed tag: $TAG"
-
-      # GitHub Release (binaries + CycloneDX SBOMs) is owned solely by
-      # .github/workflows/release.yml on tag push — avoids racing softprops here.
-      - name: Release workflow will run for new tag
-        if: steps.check_tag.outputs.exists == 'false'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          echo "Pushed v${VERSION}. The Release workflow creates the GitHub Release and assets."
->>>>>>> origin/main
->>>>>>> origin/main
+    uses: KooshaPari/phenoShared/.github/workflows/reusable/tag-automation.yml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
## **User description**
Wave-2 dedup: replaces inline workflow with call to KooshaPari/phenoShared reusable. See KooshaPari/phenoShared PR #90.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Moderate risk because tag creation behavior is now controlled by an external reusable workflow pinned to `@main`, so upstream changes could affect release/tagging unexpectedly.
> 
> **Overview**
> Delegates `Tag Automation` on `v*` tag pushes to `KooshaPari/phenoShared/.github/workflows/reusable/tag-automation.yml@main`, removing the previously inlined tagging logic (and conflict markers) from this repo.
> 
> Keeps `contents: write` permissions so the shared workflow can create/push tags as needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbc754a0d480711db1c64d4c667d902e91f54b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Delegate version-tag automation to the shared release workflow

### What Changed
- Tags pushed as `v*` now run through the shared workflow instead of the repo’s inline tagging steps
- The tag workflow still runs on version tags and keeps permission to create and push tags
- Tag creation behavior is now managed in one shared place used across repos

### Impact
`✅ Consistent release tagging`
`✅ Fewer release workflow updates`
`✅ Same tag-push behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=qzBl8ZCkH4LR5h1n5Tx5q3D_maH69qQ4ygsyiAnrAx4&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
