### PR TITLE
chore: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ai-testing-orchestration.yml
+++ b/.github/workflows/ai-testing-orchestration.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '0 5 * * 0'  # Weekly cross-project
 
+permissions:
+  contents: read
+
 jobs:
   orchestration:
     name: Test Orchestration

--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -4,6 +4,9 @@ on:
     - cron: '17 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     uses: KooshaPari/phenoShared/.github/workflows/reusable/alert-sync-issues.yml@6a6e1b06026e9443449e419a2892cd0e47c19442

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '17 4 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     uses: KooshaPari/phenoShared/.github/workflows/reusable/codeql.yml@30358ce629168f0e1ec3699706cb73d1f77cb751

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/example-reusable.yml
+++ b/.github/workflows/example-reusable.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   # Example 1: Use the Rust quality gate
   quality:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   cargo-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   tfsec:
     runs-on: ubuntu-latest

--- a/.github/workflows/legacy-tooling-gate.yml
+++ b/.github/workflows/legacy-tooling-gate.yml
@@ -10,6 +10,9 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   legacy-tooling-scan:
     uses: KooshaPari/phenoShared/.github/workflows/legacy-tooling-gate.yml@main

--- a/.github/workflows/libs-activation-ci.yml
+++ b/.github/workflows/libs-activation-ci.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'libs/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,5 +1,8 @@
 name: quality-gate
 on: [pull_request]
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,10 @@ on:
     - cron: '0 2 * * *'  # Daily at 2am UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 concurrency:
   group: security-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -5,6 +5,9 @@ name: self-merge-gate
 
 on: [pull_request_review]
 
+permissions:
+  contents: read
+
 jobs:
   gate:
     uses: KooshaPari/phenoShared/.github/workflows/reusable/self-merge-gate.yml@main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -12,6 +12,9 @@ on:
       - FUNCTIONAL_REQUIREMENTS.md
       - docs/reference/SPEC_BRANCH_WORKFLOW.md
 
+permissions:
+  contents: read
+
 jobs:
   validate-specs:
     runs-on: ubuntu-latest
@@ -144,4 +147,3 @@ jobs:
               repo: context.repo.repo,
               body: '✅ Spec validation passed! All FR IDs are unique and format is valid.'
             })
-

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   tag:
     uses: KooshaPari/phenoShared/.github/workflows/reusable/tag-automation.yml@main

--- a/.github/workflows/traceability-gate.yml
+++ b/.github/workflows/traceability-gate.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate-traceability:
     runs-on: ubuntu-latest

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   trivy-fs:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-maintenance.yml
+++ b/.github/workflows/workflow-maintenance.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 2 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   validate-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-sync.yml
+++ b/.github/workflows/workflow-sync.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/zap-dast.yml
+++ b/.github/workflows/zap-dast.yml
@@ -6,6 +6,9 @@ on:
       - 'docs/**'
       - 'src/**'
 
+permissions:
+  contents: read
+
 jobs:
   zap:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds top-level `permissions:` baseline (`contents: read`, plus `security-events: write` for SARIF uploaders) to workflows missing it. Skips publish/release/deploy and reusable (`workflow_call`) workflows. Wave-2 of workflow permissions hardening.