### PR TITLE
chore(ci): wave 10 workflow least-privilege permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,8 @@ on:
         type: string
         description: 'Directory containing repos to audit'
 
+permissions:
+  contents: read
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,8 @@ on:
         type: string
         description: 'Version for changelog entry'
 
+permissions:
+  contents: read
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gate-check.yml
+++ b/.github/workflows/gate-check.yml
@@ -16,6 +16,8 @@ on:
         type: string
         description: 'Risk profile (low, medium, high)'
 
+permissions:
+  contents: read
 jobs:
   gate-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -35,6 +35,8 @@ on:
       CARGO_TOKEN:
         required: false
 
+permissions:
+  contents: read
 jobs:
   gate-check:
     uses: ./.github/workflows/gate-check.yml


### PR DESCRIPTION
## **User description**
## Wave 10 — Workflow least-privilege permissions

Adds top-level `permissions: contents: read` to workflows missing explicit perms. SARIF-uploading workflows additionally get `security-events: write`.

Edited: 5 workflow(s)
Skipped: 36 (already-permissioned / publish-release / reusable)

Refs: API-only Python wave 10.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens GitHub Actions workflow token permissions by explicitly setting `contents: read`, with no changes to build/release logic.
> 
> **Overview**
> Adds top-level `permissions: contents: read` to several GitHub Actions workflows (including reusable `audit`, `changelog`, `gate-check`, `promote`, and the VitePress `deploy` workflow) to enforce least-privilege defaults.
> 
> The deploy workflow retains its existing job-level `pages: write`/`id-token: write` permissions while also declaring the repo-wide `contents: read` permission explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7210628b667cc59a2bbc975717fbf9fa0d7d3b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Tighten workflow access for several CI jobs**

### What Changed
- Adds read-only repository access to the changelog, audit, gate check, promote, and docs deploy workflows
- Keeps the deploy workflow’s existing publishing permissions while making the default repo access explicit
- Reduces the chance of workflows using broader access than they need

### Impact
`✅ Safer CI runs`
`✅ Lower risk from workflow tokens`
`✅ Fewer over-permissioned automation jobs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=9FWywIVz8vwPNcoLQuoFEZp9GXYycwR-8lQkbDKXZEQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
