### PR TITLE
ci(codeql): add Rust CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-rust.yml
+++ b/.github/workflows/codeql-rust.yml
@@ -1,0 +1,33 @@
+name: CodeQL (Rust)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 2'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"


### PR DESCRIPTION
Per memory feedback_codeql_no_rust_default_setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds an additional CodeQL scan workflow; minimal production risk beyond potential CI time/duplication.
> 
> **Overview**
> Adds a standalone GitHub Actions workflow (`.github/workflows/codeql-rust.yml`) to run **CodeQL static analysis for Rust** on pushes and PRs to `main`, on a weekly cron schedule, and via manual dispatch.
> 
> The job checks out the repo, initializes CodeQL for `rust`, runs `autobuild`, and uploads SARIF results with `security-events: write` permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 960ad3ce049fe6891e758da7061d0f3549df6cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->