### PR TITLE
ci(HexaKit): stabilize SAST quick checks

### DIFF
--- a/.github/workflows/sast-quick.yml
+++ b/.github/workflows/sast-quick.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+        continue-on-error: true
 
   secrets:
     name: Secret Scanning
@@ -65,5 +66,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: licensefinder/license_finder_action@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - name: Run LicenseFinder
+        run: |
+          gem install license_finder
+          license_finder
         continue-on-error: true

--- a/crates/phenotype-casbin-wrapper/Cargo.toml
+++ b/crates/phenotype-casbin-wrapper/Cargo.toml
@@ -13,3 +13,4 @@ casbin = "2"
 tokio = { version = "1", features = ["sync", "rt"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
+tracing = { workspace = true }


### PR DESCRIPTION
## **User description**
## Summary
- make Semgrep SARIF upload non-blocking when no SARIF file is produced
- replace removed `licensefinder/license_finder_action` with inline LicenseFinder gem invocation
- add missing `tracing` dependency for `phenotype-casbin-wrapper`, matching its source usage

## Validation
- `actionlint -color=false .github/workflows/sast-quick.yml`
- `git diff --check .github/workflows/sast-quick.yml crates/phenotype-casbin-wrapper/Cargo.toml`
- `cargo check -p phenotype-casbin-wrapper`

Fixes #2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/config changes plus a single dependency add; main impact is that some security/license check failures will no longer fail the workflow when tooling outputs are missing or flaky.
> 
> **Overview**
> Stabilizes the `SAST Quick Check` GitHub Actions workflow by making Semgrep SARIF upload non-blocking and replacing the removed `licensefinder/license_finder_action` with an inline Ruby `license_finder` install/run.
> 
> Fixes a build/config mismatch by adding the missing workspace `tracing` dependency to `phenotype-casbin-wrapper` (matching its `tracing::info!` usage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae4e22717d310820f50a1bde398be760b0db263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep CI checks from failing on missing scan output and restore license checks**

### What Changed
- The Semgrep upload step no longer fails the workflow when no SARIF report is produced
- The license compliance job now runs LicenseFinder directly after setting up Ruby, instead of relying on the removed GitHub Action
- Added the missing Rust dependency needed for the `phenotype-casbin-wrapper` crate to compile during lint checks

### Impact
`✅ Fewer CI failures from missing security scan files`
`✅ More reliable license compliance checks`
`✅ Fewer Rust lint build failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=wD6f9eo7yLgJkQ2VaTU_jo1S0ffucNL25-nHYf1HaDw&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
