### PR TITLE
ci(HexaKit): repair Rust manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,8 +1083,10 @@ version = "0.1.0"
 dependencies = [
  "casbin",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/phenotype-casbin-wrapper/Cargo.toml
+++ b/crates/phenotype-casbin-wrapper/Cargo.toml
@@ -10,7 +10,10 @@ path = "src/lib.rs"
 
 [dependencies]
 casbin = "2"
-tokio = { version = "1", features = ["sync", "rt"] }
+tokio = { version = "1", features = ["sync", "rt", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,12 +5,14 @@ edition = "2024"
 description = "Generated gRPC stubs for AgilePlus"
 license = "MIT"
 
+[workspace]
+
 [dependencies]
 prost = "0.13"
-tonic = { workspace = true }
+tonic = { version = "0.12", features = ["transport"] }
 
 [package.metadata.cargo-machete]
 ignored = ["prost"]
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-build = "0.12"


### PR DESCRIPTION
## **User description**
## Summary
- make rust/ a standalone cargo workspace root and replace invalid workspace-inherited tonic deps
- enable Tokio test macros for phenotype-casbin-wrapper tests
- add tempfile as a dev dependency and refresh Cargo.lock package metadata

## Validation
- cd rust && cargo metadata --no-deps --format-version 1
- cd rust && cargo check -q
- cargo test -p phenotype-casbin-wrapper --no-run -q
- git diff --check rust/Cargo.toml crates/phenotype-casbin-wrapper/Cargo.toml

Fixes #11

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only changes: adjusts dependency declarations and workspace boundaries without touching runtime code, with main risk limited to build/test resolution differences.
> 
> **Overview**
> Fixes Rust manifest issues by making `rust/` a standalone Cargo workspace root and replacing invalid workspace-inherited `tonic`/`tonic-build` dependencies with explicit `0.12` versions.
> 
> Updates `phenotype-casbin-wrapper` to enable Tokio `macros` (for tests) and adds `tempfile` as a dev-dependency; `Cargo.lock` is refreshed accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7a73b866d136635beff1e271baef9d3ae0b2d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Repair Rust manifest configuration so the workspace and tests build correctly**

### What Changed
- Made the Rust folder a standalone Cargo workspace root so its packages resolve on their own
- Replaced inherited `tonic` and `tonic-build` entries with explicit versions so the generated gRPC crate can build cleanly
- Enabled Tokio macros for the casbin wrapper tests and added `tempfile` for test support

### Impact
`✅ Fewer Rust build failures`
`✅ Working gRPC stub generation`
`✅ Shorter setup for Rust tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=65FkBc5EB1RYpBdmr3Tbd2e0Ad5O89qwKT-oSYR0U8E&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
