### PR TITLE
docs(iconography): complete Fluent + Material icon sets (20+20)

### DIFF
--- a/docs/operations/iconography/fluent/alert-triangle.svg
+++ b/docs/operations/iconography/fluent/alert-triangle.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="alert-triangle" focusable="false">
+  <title>Alert Triangle</title>
+  <desc>A warning triangle with exclamation mark</desc>
+  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="12" y1="9" x2="12" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/operations/iconography/fluent/build.svg
+++ b/docs/operations/iconography/fluent/build.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="build" focusable="false">
+  <title>Build</title>
+  <desc>A wrench tool for building and compiling</desc>
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/chart-bar.svg
+++ b/docs/operations/iconography/fluent/chart-bar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="chart-bar" focusable="false">
+  <title>Bar Chart</title>
+  <desc>A bar chart showing analytics data</desc>
+  <path d="M12 20V10M18 20V4M6 20v-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/clock.svg
+++ b/docs/operations/iconography/fluent/clock.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="clock" focusable="false">
+  <title>Clock</title>
+  <desc>A circular clock face showing time</desc>
+  <path d="M12 6v6l4 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/database.svg
+++ b/docs/operations/iconography/fluent/database.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="database" focusable="false">
+  <title>Database</title>
+  <desc>A database storage cylinder icon</desc>
+  <ellipse cx="12" cy="5" rx="9" ry="3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/deploy.svg
+++ b/docs/operations/iconography/fluent/deploy.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="deploy" focusable="false">
+  <title>Deploy</title>
+  <desc>A rocket icon for deploying applications</desc>
+  <path d="M12 2L8 8l-6 1 4 4-1 6 6-3 6 3-1-6 4-4-6-1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M9 17l-3 3M15 17l3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/file.svg
+++ b/docs/operations/iconography/fluent/file.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="file" focusable="false">
+  <title>File</title>
+  <desc>A document file icon</desc>
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <polyline points="14,2 14,8 20,8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/folder.svg
+++ b/docs/operations/iconography/fluent/folder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="folder" focusable="false">
+  <title>Folder</title>
+  <desc>A folder for organizing files</desc>
+  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/key.svg
+++ b/docs/operations/iconography/fluent/key.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="key" focusable="false">
+  <title>Key</title>
+  <desc>A security key icon</desc>
+  <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/fluent/shield.svg
+++ b/docs/operations/iconography/fluent/shield.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="shield" focusable="false">
+  <title>Shield</title>
+  <desc>A protective shield icon</desc>
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/alert-triangle-outline.svg
+++ b/docs/operations/iconography/material/alert-triangle-outline.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="alert-triangle-outline" focusable="false">
+  <title>Alert Triangle</title>
+  <desc>A warning triangle with exclamation mark</desc>
+  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="12" y1="9" x2="12" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/operations/iconography/material/build-outline.svg
+++ b/docs/operations/iconography/material/build-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="build-outline" focusable="false">
+  <title>Build</title>
+  <desc>A wrench tool for building and compiling</desc>
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/chart-bar-outline.svg
+++ b/docs/operations/iconography/material/chart-bar-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="chart-bar-outline" focusable="false">
+  <title>Bar Chart</title>
+  <desc>A bar chart showing analytics data</desc>
+  <path d="M12 20V10M18 20V4M6 20v-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/clock-outline.svg
+++ b/docs/operations/iconography/material/clock-outline.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="clock-outline" focusable="false">
+  <title>Clock</title>
+  <desc>A circular clock face showing time</desc>
+  <path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/database-outline.svg
+++ b/docs/operations/iconography/material/database-outline.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="database-outline" focusable="false">
+  <title>Database</title>
+  <desc>A database storage cylinder icon</desc>
+  <ellipse cx="12" cy="5" rx="9" ry="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/deploy-outline.svg
+++ b/docs/operations/iconography/material/deploy-outline.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="deploy-outline" focusable="false">
+  <title>Deploy</title>
+  <desc>A rocket icon for deploying applications</desc>
+  <path d="M12 2L8 8l-6 1 4 4-1 6 6-3 6 3-1-6 4-4-6-1z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M9 17l-3 3M15 17l3 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/file-outline.svg
+++ b/docs/operations/iconography/material/file-outline.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="file-outline" focusable="false">
+  <title>File</title>
+  <desc>A document file icon</desc>
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <polyline points="14,2 14,8 20,8" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/folder-outline.svg
+++ b/docs/operations/iconography/material/folder-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="folder-outline" focusable="false">
+  <title>Folder</title>
+  <desc>A folder for organizing files</desc>
+  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/key-outline.svg
+++ b/docs/operations/iconography/material/key-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="key-outline" focusable="false">
+  <title>Key</title>
+  <desc>A security key icon</desc>
+  <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/operations/iconography/material/shield-outline.svg
+++ b/docs/operations/iconography/material/shield-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="shield-outline" focusable="false">
+  <title>Shield</title>
+  <desc>A protective shield icon</desc>
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
- Complete Fluent icon set to 20 icons (added clock, chart-bar, folder, file, database, key, shield, alert-triangle, build, deploy)
- Complete Material outline icon set to 20 icons (same 10 + outline variants)
- All icons validated via Python XML parse

## Test plan
- [ ] All 20 Fluent SVGs pass XML validation
- [ ] All 20 Material outline SVGs pass XML validation
- [ ] icons.svg sprite contains all 40 symbol definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new documentation SVG assets only, with no runtime code or behavior changes.
> 
> **Overview**
> Adds new SVG icon files under `docs/operations/iconography/` for **Fluent** and **Material (outline)** sets, covering common operational concepts (e.g., alert, build, deploy, data, time, security).
> 
> Each icon includes accessible metadata (`title`, `desc`, `aria-label`) and uses `currentColor` strokes, standardizing how these icons render in docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f6db988ee7addf0e55c8c069bc017b58ab5a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->