### PR TITLE
feat: migrate KodeVibe rules into HexaKit compliance scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "phenotype-compliance-scanner"
+version = "0.2.0"
+dependencies = [
+ "regex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "phenotype-config-core"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/phenotype-cache-adapter",
   "crates/phenotype-contract",
   "crates/phenotype-contracts",
+  "crates/phenotype-compliance-scanner",
   "crates/phenotype-cost-core",
   "crates/phenotype-crypto",
   "crates/phenotype-error-core",

--- a/crates/phenotype-compliance-scanner/Cargo.toml
+++ b/crates/phenotype-compliance-scanner/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "phenotype-compliance-scanner"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+regex.workspace = true
+thiserror.workspace = true

--- a/crates/phenotype-compliance-scanner/src/lib.rs
+++ b/crates/phenotype-compliance-scanner/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides compliance scanning functionality for security and policy enforcement.
 
+use regex::Regex;
 use thiserror::Error;
 
 /// Result type for compliance operations
@@ -52,6 +53,152 @@ impl std::fmt::Display for Severity {
 /// Scanner for compliance checks
 pub struct Scanner {
     rules: Vec<Box<dyn ComplianceRule>>,
+}
+
+/// KodeVibe rule category configuration.
+#[derive(Debug, Clone)]
+pub struct KodeVibeCategoryConfig {
+    pub enabled: bool,
+    pub level: String,
+    pub max_function_length: Option<u32>,
+    pub max_nesting_depth: Option<u32>,
+    pub max_bundle_size: Option<String>,
+    pub min_commit_message_length: Option<u32>,
+    pub check_vulnerabilities: Option<bool>,
+}
+
+impl KodeVibeCategoryConfig {
+    fn new(enabled: bool, level: impl Into<String>) -> Self {
+        Self {
+            enabled,
+            level: level.into(),
+            max_function_length: None,
+            max_nesting_depth: None,
+            max_bundle_size: None,
+            min_commit_message_length: None,
+            check_vulnerabilities: None,
+        }
+    }
+}
+
+/// Full KodeVibe rule-set configuration.
+#[derive(Debug, Clone)]
+pub struct KodeVibeRuleSet {
+    pub security: KodeVibeCategoryConfig,
+    pub code: KodeVibeCategoryConfig,
+    pub performance: KodeVibeCategoryConfig,
+    pub file: KodeVibeCategoryConfig,
+    pub git: KodeVibeCategoryConfig,
+    pub dependency: KodeVibeCategoryConfig,
+    pub documentation: KodeVibeCategoryConfig,
+}
+
+impl Default for KodeVibeRuleSet {
+    fn default() -> Self {
+        Self {
+            security: KodeVibeCategoryConfig::new(true, "strict"),
+            code: KodeVibeCategoryConfig {
+                max_function_length: Some(50),
+                max_nesting_depth: Some(4),
+                ..KodeVibeCategoryConfig::new(true, "moderate")
+            },
+            performance: KodeVibeCategoryConfig {
+                max_bundle_size: Some("2MB".to_string()),
+                ..KodeVibeCategoryConfig::new(true, "moderate")
+            },
+            file: KodeVibeCategoryConfig::new(true, "strict"),
+            git: KodeVibeCategoryConfig {
+                min_commit_message_length: Some(10),
+                ..KodeVibeCategoryConfig::new(true, "moderate")
+            },
+            dependency: KodeVibeCategoryConfig {
+                check_vulnerabilities: Some(true),
+                ..KodeVibeCategoryConfig::new(true, "moderate")
+            },
+            documentation: KodeVibeCategoryConfig::new(false, "moderate"),
+        }
+    }
+}
+
+/// Regex-backed KodeVibe compliance rule.
+pub struct KodeVibeRule {
+    id: String,
+    description: String,
+    message: String,
+    severity: Severity,
+    pattern: Regex,
+}
+
+impl KodeVibeRule {
+    pub fn new(
+        id: impl Into<String>,
+        description: impl Into<String>,
+        message: impl Into<String>,
+        severity: Severity,
+        pattern: impl AsRef<str>,
+    ) -> Result<Self> {
+        Ok(Self {
+            id: id.into(),
+            description: description.into(),
+            message: message.into(),
+            severity,
+            pattern: Regex::new(pattern.as_ref())?,
+        })
+    }
+}
+
+impl ComplianceRule for KodeVibeRule {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn check(&self, target: &ScanTarget) -> Result<ComplianceResult> {
+        let content = match target {
+            ScanTarget::Content(content) => content.as_str(),
+            ScanTarget::File(path) | ScanTarget::Directory(path) => path.as_str(),
+        };
+
+        let passed = !self.pattern.is_match(content);
+        Ok(ComplianceResult {
+            rule_id: self.id.clone(),
+            passed,
+            message: if passed {
+                format!("{} passed", self.description)
+            } else {
+                self.message.clone()
+            },
+            severity: self.severity,
+        })
+    }
+}
+
+pub fn default_kodevibe_rules() -> Vec<Box<dyn ComplianceRule>> {
+    vec![
+        Box::new(
+            KodeVibeRule::new(
+                "KODEVIBE-001",
+                "Remove console.log statements before committing",
+                "Remove console.log statements before committing",
+                Severity::Low,
+                r"console\.log\(",
+            )
+            .expect("valid kodevibe console.log rule"),
+        ),
+        Box::new(
+            KodeVibeRule::new(
+                "KODEVIBE-002",
+                "TODO comments should be tracked in issues",
+                "TODO comments should be tracked in issues",
+                Severity::Info,
+                r"(?i)\b(todo|fixme|hack|xxx)\b",
+            )
+            .expect("valid kodevibe todo rule"),
+        ),
+    ]
 }
 
 /// Trait for compliance rules
@@ -133,5 +280,24 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert!(results[0].passed);
+    }
+
+    #[test]
+    fn test_kodevibe_console_log_rule_fires() {
+        let rule = default_kodevibe_rules()
+            .into_iter()
+            .find(|rule| rule.id() == "KODEVIBE-001")
+            .expect("console.log rule should exist");
+
+        let result = rule
+            .check(&ScanTarget::Content("console.log('debug');".to_string()))
+            .expect("rule check should succeed");
+
+        assert!(!result.passed);
+        assert_eq!(result.rule_id, "KODEVIBE-001");
+        assert_eq!(
+            result.message,
+            "Remove console.log statements before committing"
+        );
     }
 }

--- a/templates/quality/kodevibe-rules.yaml
+++ b/templates/quality/kodevibe-rules.yaml
@@ -1,0 +1,34 @@
+# KodeVibe Configuration
+vibes:
+  security:
+    enabled: true
+    level: strict
+  code:
+    enabled: true
+    level: moderate
+    max_function_length: 50
+    max_nesting_depth: 4
+  performance:
+    enabled: true
+    level: moderate
+    max_bundle_size: '2MB'
+  file:
+    enabled: true
+    level: strict
+  git:
+    enabled: true
+    min_commit_message_length: 10
+  dependency:
+    enabled: true
+    check_vulnerabilities: true
+  documentation:
+    enabled: false
+custom_rules:
+  - name: no-console-log
+    pattern: 'console\.log\('
+    message: Remove console.log statements before committing
+    severity: warning
+  - name: todo-comments
+    pattern: '(?i)\b(todo|fixme|hack|xxx)\b'
+    message: TODO comments should be tracked in issues
+    severity: info


### PR DESCRIPTION
## **User description**
Migrate the KodeVibe rule configuration into phenotype-compliance-scanner, add the YAML template, and verify the scanner builds and the console-log rule test passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New library code and templates only; no changes to auth, runtime services, or existing call sites yet.
> 
> **Overview**
> **KodeVibe policy is now represented in `phenotype-compliance-scanner`**, with regex-backed rules on the existing `ComplianceRule` / `Scanner` API and a matching quality template.
> 
> The crate gains **`KodeVibeRuleSet` / `KodeVibeCategoryConfig`** defaults (security, code, performance, git, dependency, etc.), a **`KodeVibeRule`** type that fails when content matches a pattern, and **`default_kodevibe_rules()`** with built-in checks for `console.log` and TODO/FIXME-style comments. **`regex`** is added as a dependency, and a unit test asserts the console-log rule fails on sample content.
> 
> **`templates/quality/kodevibe-rules.yaml`** mirrors those defaults and declares the same custom regex rules for tooling that reads YAML. The workspace **`Cargo.toml`** / lockfile register **`phenotype-compliance-scanner`** as a member crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ad456927f4bd89b12f82825e11124ff08d0fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add KodeVibe compliance rules to the scanner and matching quality template**

### What Changed
- The compliance scanner now includes a built-in KodeVibe rule set with checks for `console.log` calls and TODO/FIXME-style comments
- The new rule set also carries default category settings for security, code, performance, git, dependency, and documentation checks
- A matching YAML template was added so tooling can read the same KodeVibe rules outside the scanner
- A test now confirms the `console.log` rule fails when debug logging is present

### Impact
`✅ Fewer debug logs in committed code`
`✅ Fewer leftover TODO and FIXME comments`
`✅ Consistent compliance checks in code and YAML`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
