### PR TITLE
fix(Traceon): resolve build bugs, add to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ description = "Phenotype Infrastructure Kit"
 [workspace]
 resolver = "2"
 exclude = [
-  "Traceon",  # Source has pre-existing trait impl bugs; tracked for fix in follow-up
   "crates/cipher",  # Source has pre-existing visibility/API bugs; tracked for fix in follow-up
 ]
 members = [
+  "Traceon",
   "crates/phenotype-async-traits",
   "crates/phenotype-cache-adapter",
   "crates/phenotype-contract",

--- a/Traceon/src/application/tracer_provider.rs
+++ b/Traceon/src/application/tracer_provider.rs
@@ -5,8 +5,6 @@ use async_trait::async_trait;
 
 use crate::domain::*;
 
-pub type TraceResult<T> = Result<T, TraceError>;
-
 pub struct TracerProviderBuilder {
     name: String,
     version: Option<String>,
@@ -81,18 +79,15 @@ pub struct TracerInstance<'a> {
 
 impl<'a> Tracer for TracerInstance<'a> {
     fn span(&self, name: &str) -> Box<dyn SpanHandle> {
-        let span = Span::new(name, uuid::Uuid::new_v4());
-        Box::new(span) as Box<dyn SpanHandle>
+        Box::new(ActiveSpan::new(Span::new(name, uuid::Uuid::new_v4())))
     }
 
     fn span_with_parent(&self, name: &str, parent: &SpanContext) -> Box<dyn SpanHandle> {
-        let span = Span::new(name, parent.trace_id);
-        Box::new(span) as Box<dyn SpanHandle>
+        Box::new(ActiveSpan::new(Span::new(name, parent.trace_id)))
     }
 
     fn span_with_kind(&self, name: &str, kind: SpanKind) -> Box<dyn SpanHandle> {
-        let span = Span::new(name, uuid::Uuid::new_v4()).with_kind(kind);
-        Box::new(span) as Box<dyn SpanHandle>
+        Box::new(ActiveSpan::new(Span::new(name, uuid::Uuid::new_v4()).with_kind(kind)))
     }
 
     fn name(&self) -> &str {

--- a/Traceon/src/domain/context.rs
+++ b/Traceon/src/domain/context.rs
@@ -12,13 +12,18 @@ pub struct W3CTraceContext {
 impl W3CTraceContext {
     pub fn new(trace_id: Uuid, span_id: Uuid, sampled: bool) -> Self {
         let flags = if sampled { "01" } else { "00" };
-        let traceparent = format!("00-{}-{}-{}", trace_id, span_id, flags);
+        // W3C traceparent: 00-<32hex trace-id>-<16hex parent-id>-<2hex flags>
+        let tid = format!("{:032x}", trace_id.as_u128());
+        let sid = format!("{:016x}", (span_id.as_u128() & 0xFFFF_FFFF_FFFF_FFFF) as u64);
+        let traceparent = format!("00-{}-{}-{}", tid, sid, flags);
         Self { traceparent }
     }
 
     pub fn trace_id(&self) -> Option<Uuid> {
-        let parts: Vec<&str> = self.traceparent.split('-').collect();
+        // traceparent = "00-<32hex>-<16hex>-<2hex>"
+        let parts: Vec<&str> = self.traceparent.splitn(4, '-').collect();
         if parts.len() >= 2 {
+            // Parse 32 hex chars as UUID (no hyphens)
             Uuid::parse_str(parts[1]).ok()
         } else {
             None
@@ -37,8 +42,8 @@ pub struct B3Context {
 impl B3Context {
     pub fn new(trace_id: Uuid, span_id: Uuid, sampled: bool) -> Self {
         Self {
-            trace_id: Some(trace_id.to_string().replace("-", "")),
-            span_id: Some(format!("{:016x}", span_id.as_u128())),
+            trace_id: Some(format!("{:032x}", trace_id.as_u128())),
+            span_id: Some(format!("{:016x}", (span_id.as_u128() & 0xFFFF_FFFF_FFFF_FFFF) as u64)),
             sampled: Some(sampled),
         }
     }

--- a/Traceon/src/domain/span.rs
+++ b/Traceon/src/domain/span.rs
@@ -1,10 +1,9 @@
 //! Span - Domain Entity
 
+use std::sync::Mutex;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
-use super::SpanStatus;
 
 /// Span ID
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -33,7 +32,7 @@ pub enum SpanKind {
 }
 
 /// Span status
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SpanStatus {
     Unset,
     Ok,
@@ -154,6 +153,39 @@ pub struct SpanContext {
     pub trace_id: Uuid,
     pub span_id: Uuid,
     pub sampled: bool,
+}
+
+/// Thread-safe active span that implements SpanHandle via interior mutability.
+pub struct ActiveSpan(pub Mutex<Span>);
+
+impl ActiveSpan {
+    pub fn new(span: Span) -> Self {
+        Self(Mutex::new(span))
+    }
+
+    pub fn into_inner(self) -> Span {
+        self.0.into_inner().expect("mutex poisoned")
+    }
+}
+
+impl super::SpanHandle for ActiveSpan {
+    fn set_attribute(&self, key: String, value: super::AttributeValue) {
+        if let Ok(mut s) = self.0.lock() {
+            s.set_attribute(key, value);
+        }
+    }
+
+    fn add_event(&self, name: String) {
+        if let Ok(mut s) = self.0.lock() {
+            s.add_event(name);
+        }
+    }
+
+    fn end(&self) {
+        if let Ok(mut s) = self.0.lock() {
+            s.end();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/Traceon/src/domain/tracer.rs
+++ b/Traceon/src/domain/tracer.rs
@@ -1,9 +1,8 @@
 //! Tracer Trait - Port Interface
 
 use async_trait::async_trait;
-use uuid::Uuid;
 
-use super::{Span, SpanKind, SpanContext, TraceId};
+use super::{SpanKind, SpanContext};
 
 /// Tracer trait - primary port
 #[async_trait]


### PR DESCRIPTION
## **User description**
## Summary
- **SpanStatus Copy bug**: Removed `Copy` derive — `String` field in `Error` variant is not `Copy`
- **SpanHandle not implemented**: Added `ActiveSpan(Mutex<Span>)` wrapper that implements `SpanHandle` via interior mutability; `TracerInstance` now returns `Box<ActiveSpan>`
- **W3C traceparent format**: Fixed `trace_id` to 32 lowercase hex chars (`as_u128()` formatted) and `span_id` to 16 lowercase hex chars (lower 64 bits) per W3C spec
- **Duplicate TraceResult**: Removed re-declaration in `tracer_provider.rs`; `TraceResult` already re-exported from `domain/errors.rs`
- **Workspace**: Removed `Traceon` from `exclude`, added to `members`; `cargo check --workspace` green
- **cipher**: Remains excluded — `CipherError`/`Key`/`Nonce` types missing from `core/mod.rs` (deeper API gap, not a quick fix)

## Test plan
- [x] `cargo check -p tracingkit` — clean (warnings only)
- [x] `cargo check --workspace` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect distributed trace header formatting and how spans are exposed at runtime; incorrect propagation could break cross-service correlation, though scope is limited to the Traceon crate.
> 
> **Overview**
> **Traceon** is brought back into the root workspace so `cargo check --workspace` includes it again; **cipher** stays excluded.
> 
> Compile fixes and tracing behavior updates: **`SpanStatus`** no longer derives **`Copy`** (the error variant holds a **`String`**). **`ActiveSpan`** wraps **`Span`** in a **`Mutex`** and implements **`SpanHandle`**, so **`TracerInstance`** can return **`Box<dyn SpanHandle>`** instead of boxing a type that did not implement the trait. A duplicate **`TraceResult`** alias was removed from **`tracer_provider.rs`** in favor of the domain export.
> 
> **W3C traceparent** and **B3** IDs are emitted as spec-style hex (32-char trace id, 16-char span id from the lower 64 bits of the UUID); **`trace_id()`** parsing uses **`splitn(4, '-')`** on the header value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ccf9ea3e0fea956ce747fcd232935bebb5fbd84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix Traceon span handling and trace header formatting, and include Traceon in workspace builds**

### What Changed
- Spans are now returned in a form that can be updated while they are active, so tracing calls can record attributes, events, and end marks reliably
- Trace headers now use the expected fixed-length hex format for W3C traceparent and B3 propagation, which helps other services read Traceon traces correctly
- Span status no longer uses an invalid copyable form, preventing build failures around error spans
- Traceon is included in the workspace again, so full workspace checks cover it

### Impact
`✅ Fewer trace propagation failures`
`✅ More reliable span updates during requests`
`✅ Cleaner workspace builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
