### PR TITLE
docs: rich-media stub boxes pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,23 @@ their correct locations:
 - Project-specific issues: `cd <project>` and check that project's docs
 - Architecture decisions: `cat docs/adr/INDEX.md` or inspect `docs/`
 - General questions: Check this `README.md` and the target project's `README.md` first
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="HexaKit quickstart — scaffold a new project from template" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of the terminal after running the HexaKit scaffold command.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-gif" subject="Template browser — browsing and selecting a scaffold template" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *GIF of browsing available templates and scaffolding a new project.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-mp4" subject="Template authoring — creating a new HexaKit template" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Video of authoring a new template and publishing it to the HexaKit registry.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="HexaKit architecture — template registry + scaffold engine diagram" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated component diagram of HexaKit scaffold engine and template registry.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/RICH_MEDIA.md
+++ b/RICH_MEDIA.md
@@ -1,0 +1,58 @@
+# Rich Media Convention — Phenotype Org
+
+> **Canonical location:** `KooshaPari/phenotype-registry` → `RICH_MEDIA.md`
+> Copied to each participating repo as a docs-only reference.
+
+## Stub Marker Format
+
+Insert stubs using this **exact** HTML-comment pair so fill-agents can grep them:
+
+```html
+<!-- RICH-MEDIA-STUB type="annotated-screenshot|recording-mp4|recording-gif" subject="<what>" journey="<flow>" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *<short human description of what will go here>*
+<!-- END-RICH-MEDIA-STUB -->
+```
+
+### Attribute reference
+
+| attribute | values | notes |
+|-----------|--------|-------|
+| `type` | `annotated-screenshot` \| `recording-mp4` \| `recording-gif` | pick the most appropriate |
+| `subject` | free text | what the media shows (e.g. `"VRAM plan slider UI"`) |
+| `journey` | phenotype-journeys manifest name or `""` | e.g. `"first-plan"`, `"fleet-register"` |
+| `status` | `TODO` \| `CAPTURED` \| `PUBLISHED` | fill-agent updates to `CAPTURED`/`PUBLISHED` |
+
+## Grep Targets
+
+```bash
+# all stubs
+grep -r "RICH-MEDIA-STUB" docs/
+
+# by journey
+grep -r 'journey="first-plan"' docs/
+
+# outstanding TODOs
+grep -r 'status="TODO"' docs/
+```
+
+## Expected Placement Areas (5 categories)
+
+1. **quickstart / getting-started** — `annotated-screenshot` of first-run output or install step
+2. **feature walkthroughs** — `recording-gif` per major feature
+3. **dashboard / UI pages** — `annotated-screenshot` of each major panel or view
+4. **E2E / journey flows** — `recording-mp4` tied to phenotype-journeys journey name
+5. **architecture diagrams** — `annotated-screenshot` of component map or data-flow
+
+## Journey Linkage
+
+Where a `docs/journeys/manifests/` directory exists, the `journey=` attribute **MUST** match the manifest slug exactly.
+
+Known hwLedger journeys (13): `first-plan`, `fleet-register`, `traceability-report`, `vram-reconcile`, `inference-run`, `fleet-probe`, `cost-model`, `audit-log`, `fleet-dispatch`, `model-ingest`, `telemetry-sync`, `kv-cache-plan`, `spot-price-scan`.
+
+## Fill-Agent Instructions
+
+1. Search for `status="TODO"` stubs.
+2. Capture the screenshot/recording described in `subject=`.
+3. Upload asset to `docs/assets/rich-media/<repo>/<slug>.<ext>`.
+4. Replace the placeholder callout with a real `<img>` or `<video>` tag.
+5. Change `status="TODO"` → `status="PUBLISHED"`.


### PR DESCRIPTION
## **User description**
Additive docs-only PR. Inserts RICH_MEDIA.md + 4 stubs: quickstart scaffold, template browser, template authoring, architecture diagram. Status=TODO for fill-agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no code, config, or runtime impact.
> 
> **Overview**
> Introduces the Phenotype org **rich media stub** workflow: a new root **`RICH_MEDIA.md`** defines the HTML-comment marker format, attributes (`type`, `subject`, `journey`, `status`), grep targets, placement categories, journey linkage, and fill-agent steps to replace placeholders with assets under `docs/assets/rich-media/`.
> 
> **`README.md`** gains a **Rich Media Stubs** section with four **`status="TODO"`** placeholders—quickstart scaffold screenshot, template browser GIF, template authoring video, and architecture diagram—so a fill-agent can capture and publish media later without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0478649a794dec0c16b74bdc5437fecd485916dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add rich media stub guidance and placeholders for HexaKit docs

### What Changed
- Added a shared guide for how to mark rich media placeholders, including the required format, allowed values, and where to place them
- Added four TODO placeholders in the README for the quickstart, template browser, template authoring flow, and architecture diagram
- Included instructions for how these placeholders should later be replaced with published images or videos

### Impact
`✅ Clearer docs capture workflow`
`✅ Easier follow-up for screenshots and videos`
`✅ Fewer missing media placeholders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
