### PR TITLE
feat: adopt phenotype-sentry-config + phenotype-contract-tests (routing-convergence #24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ exclude = [
   "crates/focalpoint",  # 867MB repo with vendor dir; fetch too large for subtree-add; pending manual absorption
 ]
 members = [
+  "crates/phenotype-contract-tests",
+  "crates/phenotype-sentry-config",
   "Traceon",
   "crates/phenotype-async-traits",
   "crates/phenotype-cache-adapter",
@@ -66,6 +68,7 @@ members = [
   "libs/phenotype-config-core",
 ]
 [workspace.dependencies]
+sentry = "0.34"
 # Core
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/phenotype-contract-tests/Cargo.toml
+++ b/crates/phenotype-contract-tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "phenotype-contract-tests"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+chrono.workspace = true

--- a/crates/phenotype-contract-tests/src/contract.rs
+++ b/crates/phenotype-contract-tests/src/contract.rs
@@ -1,0 +1,43 @@
+//! Contract testing
+
+use chrono::{DateTime, Utc};
+
+#[derive(Debug)]
+pub struct ContractTest {
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub requirements: Vec<String>,
+}
+
+impl ContractTest {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: String::new(),
+            created_at: Utc::now(),
+            requirements: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Contract {
+    pub tests: Vec<ContractTest>,
+}
+
+impl Contract {
+    pub fn new() -> Self {
+        Self { tests: Vec::new() }
+    }
+    
+    pub fn add_test(&mut self, test: ContractTest) {
+        self.tests.push(test);
+    }
+}
+
+impl Default for Contract {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/phenotype-contract-tests/src/lib.rs
+++ b/crates/phenotype-contract-tests/src/lib.rs
@@ -1,0 +1,5 @@
+//! Contract testing utilities
+
+pub mod contract;
+
+pub use contract::{Contract, ContractTest};

--- a/crates/phenotype-sentry-config/Cargo.toml
+++ b/crates/phenotype-sentry-config/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "phenotype-sentry-config"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+sentry.workspace = true

--- a/crates/phenotype-sentry-config/src/lib.rs
+++ b/crates/phenotype-sentry-config/src/lib.rs
@@ -1,0 +1,105 @@
+//! Sentry error tracking configuration for phenotype ecosystem.
+//!
+//! Provides simple, unified Sentry SDK initialization and error capture utilities.
+
+use std::env;
+
+/// Initialize Sentry with environment-based DSN configuration.
+///
+/// Supports the following environment variables:
+/// - `SENTRY_DSN`: Sentry project DSN (optional, defaults to test mode)
+/// - `SENTRY_ENVIRONMENT`: Environment identifier (defaults to "development")
+/// - `SENTRY_RELEASE`: Release version (automatically set from cargo)
+///
+/// # Example
+/// ```ignore
+/// use phenotype_sentry_config::initialize;
+///
+/// let _guard = initialize();
+/// // Now panics and errors are automatically captured
+/// ```
+pub fn initialize() -> sentry::ClientInitGuard {
+    let dsn = env::var("SENTRY_DSN").ok();
+    let environment = env::var("SENTRY_ENVIRONMENT").unwrap_or_else(|_| "development".to_string());
+    let release = env!("CARGO_PKG_VERSION");
+
+    // Use test DSN if not provided
+    let dsn_url = dsn
+        .as_deref()
+        .unwrap_or("https://test@test.ingest.sentry.io/0");
+
+    sentry::init((
+        dsn_url,
+        sentry::ClientOptions {
+            environment: Some(environment.into()),
+            release: Some(release.into()),
+            attach_stacktrace: true,
+            debug: true,
+            ..Default::default()
+        },
+    ))
+}
+
+/// Initialize Sentry with custom client options.
+///
+/// # Example
+/// ```ignore
+/// use phenotype_sentry_config::initialize_with_options;
+///
+/// let options = sentry::ClientOptions {
+///     environment: Some("production".into()),
+///     ..Default::default()
+/// };
+/// let _guard = initialize_with_options("https://your-dsn@sentry.io/id", options);
+/// ```
+pub fn initialize_with_options(
+    dsn: &str,
+    mut options: sentry::ClientOptions,
+) -> sentry::ClientInitGuard {
+    options.attach_stacktrace = true;
+    sentry::init((dsn, options))
+}
+
+/// Capture an error event to Sentry.
+///
+/// # Example
+/// ```ignore
+/// use phenotype_sentry_config::capture_error;
+///
+/// let err = std::io::Error::last_os_error();
+/// capture_error(&err);
+/// ```
+pub fn capture_error(error: &(dyn std::error::Error + 'static)) {
+    sentry::capture_error(error);
+}
+
+/// Capture a message event to Sentry.
+///
+/// # Example
+/// ```ignore
+/// use phenotype_sentry_config::capture_message;
+///
+/// capture_message("Critical event", sentry::Level::Error);
+/// ```
+pub fn capture_message(msg: &str, level: sentry::Level) {
+    sentry::capture_message(msg, level);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initialize_without_dsn() {
+        // FR-SENTRY-001: Sentry should initialize in test mode without DSN
+        env::remove_var("SENTRY_DSN");
+        let _guard = initialize();
+    }
+
+    #[test]
+    fn test_environment_override() {
+        // FR-SENTRY-002: Environment should be overridable via env var
+        env::set_var("SENTRY_ENVIRONMENT", "test");
+        let _guard = initialize();
+    }
+}

--- a/crates/phenotype-sentry-config/tests/sentry_integration_test.rs
+++ b/crates/phenotype-sentry-config/tests/sentry_integration_test.rs
@@ -1,0 +1,40 @@
+/// Integration test for Sentry error capture in phenotype-infrakit
+///
+/// This test verifies that Sentry is properly initialized and can capture errors.
+/// Run with: cargo test --test sentry_integration_test -- --nocapture
+
+#[test]
+fn test_sentry_initialization() {
+    // FR-SENTRY-001: Sentry should initialize without panicking
+    let _guard = phenotype_sentry_config::initialize();
+    // Guard is valid, test passes
+}
+
+#[test]
+fn test_sentry_capture_message() {
+    // FR-SENTRY-002: Should be able to capture messages
+    let _guard = phenotype_sentry_config::initialize();
+    phenotype_sentry_config::capture_message(
+        "Integration test message from phenotype-infrakit",
+        sentry::Level::Info,
+    );
+    // Message captured, test passes
+}
+
+#[test]
+fn test_sentry_capture_error() {
+    // FR-SENTRY-003: Should be able to capture errors
+    let _guard = phenotype_sentry_config::initialize();
+    let error = std::io::Error::other("Test error for Sentry in phenotype-infrakit");
+    phenotype_sentry_config::capture_error(&error);
+    // Error captured, test passes
+}
+
+#[test]
+fn test_sentry_initialization_with_env_override() {
+    // FR-SENTRY-005: Environment should be overridable
+    std::env::set_var("SENTRY_ENVIRONMENT", "test");
+    let _guard = phenotype_sentry_config::initialize();
+    std::env::remove_var("SENTRY_ENVIRONMENT");
+    // Test passes
+}


### PR DESCRIPTION
## **User description**
Rehomes 2 collision-free real crates from the mislabeled phenoRouterMonitor 'InfraKit' shelf into canonical HexaKit. Build-verified: cargo metadata exit 0, both crates resolve. http-client/rate-limiter NOT migrated — they collide with existing HexaKit phenotype-http-client-core/phenotype-rate-limit and need reconciliation (escalated).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive crates and workspace metadata only; Sentry helpers default to a test DSN when unset, but no production call sites are changed in this diff.
> 
> **Overview**
> Adds two new workspace members migrated from routing convergence: **`phenotype-sentry-config`** and **`phenotype-contract-tests`**, plus a shared **`sentry = "0.34"`** workspace dependency.
> 
> **`phenotype-sentry-config`** centralizes Sentry setup: `initialize()` reads `SENTRY_DSN` / `SENTRY_ENVIRONMENT`, falls back to a test ingest DSN when DSN is missing, sets release from the crate version, and exposes `initialize_with_options`, `capture_error`, and `capture_message`. Unit and integration tests cover init without DSN, env override, and capture paths.
> 
> **`phenotype-contract-tests`** introduces lightweight **`Contract`** / **`ContractTest`** types (name, description, requirements, timestamps) for building contract-test collections—no runners or assertions in this PR.
> 
> Nothing in the diff wires these crates into existing binaries or other phenotype crates yet; this is workspace registration and new library surface only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3cb4cf10cc4d3ba11d7a7d783d04705ebf561a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add shared Sentry setup and contract test data types**

### What Changed
- Added a shared Sentry helper crate that can initialize error tracking from environment settings, fall back to a test DSN when none is set, and send errors or messages
- Added a small contract-test crate with basic contract and test records, including names, descriptions, requirements, and creation timestamps
- Registered both crates in the workspace and added Sentry as a shared dependency
- Added tests that verify Sentry starts without a DSN, respects the environment setting, and can capture messages and errors

### Impact
`✅ Easier error tracking setup`
`✅ Fewer failed starts when Sentry config is missing`
`✅ Faster reuse of contract test definitions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
