### PR TITLE
fix: pin rust base to 1.86-slim in Dockerfile.rust (rust-version 1.86)

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,4 +1,4 @@
-FROM rust:slim
+FROM rust:1.86-slim
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \


### PR DESCRIPTION
Draft PR opened during branch cleanup inventory.

Branch compare against main: ahead 1, behind 58, status diverged.

This PR needs normal review/CI before merge.