### PR TITLE
fix(mcp): migrate dashboard.phenotype.dev → dashboard.kooshapari.com

### DIFF
--- a/.mcp-testing.yaml
+++ b/.mcp-testing.yaml
@@ -157,7 +157,7 @@ notifications:
       - "#testing-alerts"
 
   dashboard:
-    url: "https://dashboard.phenotype.dev/testing"
+    url: "https://dashboard.kooshapari.com/testing"
     refresh_interval: "5m"
 
 # Metrics Collection


### PR DESCRIPTION
Draft PR opened during branch cleanup inventory.

Branch compare against main: ahead 1, behind 57, status diverged.

This PR needs normal review/CI before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config URL change with no runtime logic, auth, or data-path impact; verify the new dashboard is live before merge.
> 
> **Overview**
> Updates the MCP testing **notifications dashboard** endpoint in `.mcp-testing.yaml` from `https://dashboard.phenotype.dev/testing` to `https://dashboard.kooshapari.com/testing`. The `refresh_interval` and the rest of the notifications/metrics config are unchanged.
> 
> This is a hostname migration so reporting and alerts point at the new dashboard host; no test runners, MCP servers, or workflow definitions are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682dd64ace883b9199ebf9d094d8362bf7f6e874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->