### PR TITLE
chore(HexaKit): gitignore worktree dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,5 @@ PHENOTYPE_ERROR_CORE_EXTRACTION_REPORT.md
 
 # Rust build artifacts
 /target
+/worktrees/
+/*-wtrees/


### PR DESCRIPTION
Adds /worktrees/ and /*-wtrees/ to .gitignore to keep local-only artifacts out of the index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore rules with no effect on builds, deployments, or tracked source.
> 
> **Overview**
> Extends **`.gitignore`** at the bottom (under the Rust build artifacts section) with **`/worktrees/`** and **`/*-wtrees/`**, so repo-root worktree clone folders and `*-wtrees` naming patterns are ignored even if they are not covered by the many existing per-name worktree entries elsewhere in the file.
> 
> No runtime, CI, or application code is touched—only local artifact exclusion from the git index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04da8eb9908f0999b54cc7f76379f9527e5cf15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->