### PR TITLE
chore(HexaKit): hygiene bundle

### DIFF
--- a/scripts/orb-down.sh
+++ b/scripts/orb-down.sh
@@ -1,8 +1,8 @@
-<<<<<<< HEAD
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+
 # Stop and remove OrbStack containers for Dragonfly and PostgreSQL.
 # Uses docker CLI (OrbStack v2).
-set -e
 
 DRAGONFLY_NAME="agileplus-dragonfly"
 POSTGRES_NAME="agileplus-postgres"
@@ -18,10 +18,3 @@ for name in "${DRAGONFLY_NAME}" "${POSTGRES_NAME}"; do
 done
 
 echo "OrbStack containers cleaned up."
-=======
-#!/bin/bash
-# OrbStack container shutdown stubs
-# Containers are managed via Docker, not OrbStack
-
-echo "OrbStack shutdown (containers managed via Docker)"
->>>>>>> origin/main

--- a/scripts/orb-up.sh
+++ b/scripts/orb-up.sh
@@ -1,9 +1,9 @@
-<<<<<<< HEAD
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+
 # Start OrbStack containers for Dragonfly and PostgreSQL.
 # OrbStack v2 exposes docker CLI - this script uses docker commands.
 # Idempotent -- reuses existing containers.
-set -e
 
 DRAGONFLY_NAME="agileplus-dragonfly"
 POSTGRES_NAME="agileplus-postgres"
@@ -84,25 +84,3 @@ done
 
 echo "ERROR: Containers did not become ready in time" >&2
 exit 1
-=======
-#!/bin/bash
-# OrbStack container management stubs
-# Containers (Dragonfly, PostgreSQL) are managed directly via Docker
-
-# Verify containers are running
-if docker ps --format '{{.Names}}' | grep -q "^dragonfly$"; then
-    echo "✓ Dragonfly container is running"
-else
-    echo "Starting Dragonfly..."
-    docker run -d --name dragonfly -p 6379:6379 --ulimit memlock=-1 docker.dragonflydb.io/dragonflydb/dragonfly
-fi
-
-if docker ps --format '{{.Names}}' | grep -q "^postgres-agileplus$"; then
-    echo "✓ PostgreSQL container is running"
-else
-    echo "Starting PostgreSQL..."
-    docker run -d --name postgres-agileplus -p 5432:5432 -e POSTGRES_USER=agileplus -e POSTGRES_DB=plane -e POSTGRES_PASSWORD=agileplus-dev postgres:16-alpine
-fi
-
-echo "OrbStack containers ready"
->>>>>>> origin/main


### PR DESCRIPTION
## **User description**
## Hygiene Bundle

Comprehensive single-PR hygiene sweep covering:

- `.editorconfig` indent style to `tab`, size 2
- `set -euo pipefail` in all `*.sh` files
- `justfile` with standard recipes
- Standard files: `LICENSE`, `CODEOWNERS`, `SECURITY.md`, `CONTRIBUTING.md`, `FUNDING.yml`
- `README.md` "work-state" header

This PR was generated as part of the org-wide hygiene bundle (2026-06-08).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev helper scripts only; behavior is restored to the fuller implementation rather than changing production paths.
> 
> **Overview**
> Resolves leftover merge conflict markers in **`scripts/orb-up.sh`** and **`scripts/orb-down.sh`**, dropping the **`origin/main`** stub versions in favor of the full implementations that manage **`agileplus-dragonfly`** and **`agileplus-postgres`** via Docker.
> 
> Both scripts now use **`#!/bin/bash`** and **`set -euo pipefail`** instead of plain **`set -e`** / **`#!/bin/sh`**, matching the hygiene bundle. **`orb-down.sh`** keeps stop/remove logic for the named containers; **`orb-up.sh`** keeps idempotent start, port cleanup, env-based Postgres password, and readiness polling—without the shorter stub that used different container names and inline `docker run` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169e5975db2c95fb6e8ff40282afe6b177a7c563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Restore OrbStack container start/stop scripts**

### What Changed
- Fixed the OrbStack helper scripts so they now start and stop the expected Dragonfly and PostgreSQL containers instead of the shorter stub versions
- The scripts now fail immediately on shell errors, reducing broken local setup runs
- Container startup still waits for both services to be ready before reporting success

### Impact
`✅ Fewer broken local environment setups`
`✅ Reliable start and stop for shared dev containers`
`✅ Clearer feedback when local database or cache startup fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
