### PR TITLE
chore(HexaKit): add doctests to phenotype-time public API

### DIFF
--- a/crates/phenotype-time/src/duration.rs
+++ b/crates/phenotype-time/src/duration.rs
@@ -1,4 +1,18 @@
 //! Duration extension traits and utilities.
+//!
+//! ## Example
+//!
+//! ```
+//! use std::time::Duration;
+//! use phenotype_time::DurationExt;
+//!
+//! let d = Duration::hours(2) + Duration::minutes(15) + Duration::seconds(7);
+//! assert_eq!(d.as_secs(), 2 * 3600 + 15 * 60 + 7);
+//! assert_eq!(d.format_human(), "2h 15m 7s");
+//!
+//! // Zero is rendered as "0s" rather than an empty string.
+//! assert_eq!(Duration::seconds(0).format_human(), "0s");
+//! ```
 
 use std::time::Duration;
 
@@ -20,6 +34,24 @@ pub trait DurationExt {
     fn millis(ms: u64) -> Duration;
 
     /// Format as human-readable string (e.g., "5m 30s").
+    ///
+    /// Renders a `Duration` as a space-separated list of `<n><unit>`
+    /// components (days, hours, minutes, seconds). Zero-valued components
+    /// are omitted, and a zero `Duration` is rendered as `"0s"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use phenotype_time::DurationExt;
+    ///
+    /// assert_eq!(Duration::seconds(45).format_human(), "45s");
+    /// assert_eq!(
+    ///     (Duration::days(1) + Duration::hours(2) + Duration::minutes(3) + Duration::seconds(4))
+    ///         .format_human(),
+    ///     "1d 2h 3m 4s",
+    /// );
+    /// ```
     fn format_human(&self) -> String;
 }
 

--- a/crates/phenotype-time/src/lib.rs
+++ b/crates/phenotype-time/src/lib.rs
@@ -1,4 +1,38 @@
-//! phenotype-time
+//! `phenotype-time`
+//!
+//! Time and duration utilities for the Phenotype ecosystem.
+//!
+//! ## Features
+//!
+//! - **[`DurationExt`]** — ergonomic constructors and a human-readable
+//!   [`format_human`](DurationExt::format_human) formatter for
+//!   [`std::time::Duration`].
+//! - **[`Timestamp`]** — UTC [`chrono::DateTime<Utc>`] extensions with
+//!   ISO 8601 parse/format round-trip via [`Timestamp::to_iso`] /
+//!   [`Timestamp::parse`].
+//! - **Constants** — pre-defined TTLs, timeouts, retry/backoff windows
+//!   and per-unit seconds multipliers (see [`duration_constants`] and
+//!   [`time_constants`]).
+//!
+//! ## Quick start
+//!
+//! ```
+//! use std::time::Duration;
+//! use chrono::{DateTime, Utc};
+//! use phenotype_time::{DurationExt, Timestamp};
+//!
+//! // Build a duration with the trait and format it.
+//! let d = Duration::minutes(2) + Duration::seconds(30);
+//! assert_eq!(d.as_secs(), 150);
+//! assert_eq!(d.format_human(), "2m 30s");
+//!
+//! // ISO 8601 round-trip.
+//! let original: DateTime<Utc> = "2024-01-15T12:34:56Z".parse().unwrap();
+//! let iso = original.to_iso();
+//! let parsed = DateTime::<Utc>::parse(&iso).unwrap();
+//! assert_eq!(original, parsed);
+//! assert_eq!(parsed.to_utc(), original);
+//! ```
 
 use thiserror::Error;
 

--- a/crates/phenotype-time/src/timestamp.rs
+++ b/crates/phenotype-time/src/timestamp.rs
@@ -1,4 +1,24 @@
 //! Timestamp utilities for working with chrono DateTime.
+//!
+//! ## Example
+//!
+//! ```
+//! use chrono::{DateTime, Utc};
+//! use phenotype_time::Timestamp;
+//!
+//! // Fixed reference instant (UTC) and ISO 8601 round-trip.
+//! let original: DateTime<Utc> = "2024-01-15T12:34:56Z".parse().unwrap();
+//! let iso = original.to_iso();
+//! let parsed = DateTime::<Utc>::parse(&iso).unwrap();
+//! assert_eq!(original, parsed);
+//!
+//! // to_utc on an already-UTC value is the identity.
+//! assert_eq!(original.to_utc(), original);
+//! ```
+//!
+//! `Timestamp::now` is non-deterministic and is therefore exercised by
+//! the regular `#[test]` suite rather than doctests; run
+//! `cargo test -p phenotype-time` to execute it.
 
 use chrono::{DateTime, Utc};
 


### PR DESCRIPTION
## **User description**
Continue the cipher round-trip doctest pattern (#211) on the `phenotype-time` crate, which previously had no executable examples.

## Summary
- 4 doctests (87 lines) covering the public surface
- No behavior change; documentation-only

## Files
- `crates/phenotype-time/src/lib.rs` — quick-start example: Duration construction + format_human, DateTime<Utc> ISO 8601 round-trip
- `crates/phenotype-time/src/duration.rs` — module example + `DurationExt::format_human` example ('0s', '45s', '1d 2h 3m 4s')
- `crates/phenotype-time/src/timestamp.rs` — to_iso/parse/to_utc round-trip on a fixed 2024-01-15T12:34:56Z reference instant

## Verification
- `cargo test -p phenotype-time --doc` -> 4 passed
- `RUSTDOCFLAGS=-D warnings cargo doc -p phenotype-time --no-deps` -> clean (no broken doc links)
- `cargo clippy -p phenotype-time --all-targets -- -D warnings` -> clean

`Timestamp::now` is non-deterministic and stays exercised by the regular `#[test]` suite rather than doctests.

## Related
- 7068118 cipher round-trip doctests (#211)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no logic or API modifications; risk is limited to doctest/doc link correctness.
> 
> **Overview**
> Adds **executable rustdoc examples** across `phenotype-time` so the public API is documented with runnable snippets, following the same round-trip doctest pattern used elsewhere in HexaKit.
> 
> The crate root gains a **Features** overview and a **Quick start** doctest covering `DurationExt` construction/`format_human` and fixed-instant ISO 8601 round-trip via `Timestamp`. **`duration.rs`** adds a module-level example plus `# Examples` on `format_human` (including the `"0s"` zero case and multi-unit strings). **`timestamp.rs`** adds a module example for `to_iso`/`parse`/`to_utc` and notes that **`Timestamp::now`** stays in unit tests because it is non-deterministic.
> 
> **No runtime or API behavior changes**—only doc comments and doctests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e26f80180429ab6d522ef106053a3c301f8baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add runnable examples for the time utilities public API**

### What Changed
- Added runnable examples to the crate docs so users can see how to build, format, and compare durations and timestamps
- Documented `format_human` with clear output examples, including zero durations and mixed day/hour/minute/second values
- Added an ISO 8601 round-trip example for UTC timestamps, with a note that `now` remains covered by regular tests

### Impact
`✅ Easier first use of time helpers`
`✅ Clearer formatting examples for durations`
`✅ Safer timestamp round-trip usage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
