### PR TITLE
chore(HexaKit): add round-trip doctests to phenotype-config-core

### DIFF
--- a/libs/phenotype-config-core/src/lib.rs
+++ b/libs/phenotype-config-core/src/lib.rs
@@ -6,12 +6,51 @@
 //! 1. System config (`/etc/phenotype/<name>.toml`)
 //! 2. User config (`~/.config/phenotype/<name>.toml`)
 //! 3. Project config (`./<name>.toml`)
-//! 4. Custom paths via `with_path()`
+//! 4. Custom paths via [`ConfigLoader::with_path`]
+//!
+//! ## Quick start
+//!
+//! ```
+//! use phenotype_config_core::ConfigLoader;
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize, PartialEq, Debug)]
+//! struct AppConfig {
+//!     name: String,
+//!     port: u16,
+//! }
+//!
+//! // `load_from` reads a specific file (no env or path-cascade).
+//! let dir = tempfile::tempdir().unwrap();
+//! let path = dir.path().join("app.toml");
+//! std::fs::write(&path, "name = \"demo\"\nport = 9090\n").unwrap();
+//!
+//! let cfg: AppConfig = ConfigLoader::load_from(&path).unwrap();
+//! assert_eq!(cfg, AppConfig { name: "demo".to_string(), port: 9090 });
+//! ```
+//!
+//! [`ConfigLoader::with_path`]: ConfigLoader::with_path
 
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+/// Errors produced by the loader.
+///
+/// # Examples
+///
+/// ```
+/// use phenotype_config_core::ConfigError;
+///
+/// let not_found = ConfigError::NotFound;
+/// assert_eq!(not_found.to_string(), "config not found at any search path");
+///
+/// let io_err = ConfigError::Io(std::io::Error::new(
+///     std::io::ErrorKind::NotFound,
+///     "missing file",
+/// ));
+/// assert!(io_err.to_string().starts_with("io error: "));
+/// ```
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("io error: {0}")]
@@ -34,6 +73,24 @@ pub struct ConfigLoader {
 
 impl ConfigLoader {
     /// Create a new config loader for the given config name (e.g. "agileplus").
+    ///
+    /// The loader is seeded with three default search paths:
+    /// `<config_dir>/phenotype/<name>.toml` (when the host has a
+    /// `config_dir()`), `/etc/phenotype/<name>.toml`, and the project
+    /// cwd entry `<name>.toml`. Add more with
+    /// [`ConfigLoader::with_path`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_config_core::ConfigLoader;
+    ///
+    /// let loader = ConfigLoader::new("myapp");
+    ///
+    /// // Every search path ends in `<name>.toml`.
+    /// assert!(loader.search_paths().iter().all(|p| p.ends_with("myapp.toml")));
+    /// assert_eq!(loader.name(), "myapp");
+    /// ```
     pub fn new(name: impl Into<String>) -> Self {
         let name = name.into();
         let mut search_paths = Vec::new();
@@ -53,6 +110,25 @@ impl ConfigLoader {
     }
 
     /// Add a custom search path.
+    ///
+    /// The path is inserted just before the project-cwd entry, so it
+    /// takes precedence over `./<name>.toml` but is still beaten by
+    /// the system and user-cascade entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_config_core::ConfigLoader;
+    ///
+    /// let dir = tempfile::tempdir().unwrap();
+    /// let custom = dir.path().join("my.toml");
+    ///
+    /// let loader = ConfigLoader::new("myapp").with_path(&custom);
+    /// let paths = loader.search_paths();
+    /// assert!(paths.iter().any(|p| p == &custom));
+    /// // The original cwd entry is still last.
+    /// assert_eq!(paths.last().unwrap(), &std::path::PathBuf::from("myapp.toml"));
+    /// ```
     pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
         let pos = self.search_paths.len().saturating_sub(1);
         self.search_paths.insert(pos, path.into());
@@ -60,6 +136,26 @@ impl ConfigLoader {
     }
 
     /// Load and deserialize config from the first found file.
+    ///
+    /// Walks [`ConfigLoader::search_paths`] in order and parses the
+    /// first file that exists. Returns
+    /// [`ConfigError::NotFound`] when no entry in the cascade resolves
+    /// to a readable file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_config_core::{ConfigError, ConfigLoader};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct TestCfg;
+    ///
+    /// // A name with no on-disk entries yields `NotFound`.
+    /// let loader = ConfigLoader::new("nonexistent-phenotype-config-xyz");
+    /// let result: Result<TestCfg, _> = loader.load();
+    /// assert!(matches!(result, Err(ConfigError::NotFound)));
+    /// ```
     pub fn load<T: DeserializeOwned>(&self) -> Result<T> {
         for path in &self.search_paths {
             if path.exists() {
@@ -72,6 +168,41 @@ impl ConfigLoader {
     }
 
     /// Load from a specific file path.
+    ///
+    /// Use this when you already know the on-disk location of the
+    /// config file and want to bypass the
+    /// [`ConfigLoader::search_paths`](ConfigLoader::search_paths)
+    /// cascade.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_config_core::ConfigLoader;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize, PartialEq, Debug)]
+    /// struct DbConfig {
+    ///     url: String,
+    ///     max_conns: u16,
+    /// }
+    ///
+    /// let dir = tempfile::tempdir().unwrap();
+    /// let path = dir.path().join("db.toml");
+    /// std::fs::write(
+    ///     &path,
+    ///     "url = \"postgres://localhost/x\"\nmax_conns = 8\n",
+    /// )
+    /// .unwrap();
+    ///
+    /// let cfg: DbConfig = ConfigLoader::load_from(&path).unwrap();
+    /// assert_eq!(
+    ///     cfg,
+    ///     DbConfig {
+    ///         url: "postgres://localhost/x".to_string(),
+    ///         max_conns: 8,
+    ///     }
+    /// );
+    /// ```
     pub fn load_from<T: DeserializeOwned>(path: &Path) -> Result<T> {
         let content = std::fs::read_to_string(path)?;
         let config: T = toml::from_str(&content)?;


### PR DESCRIPTION
## **User description**
Continues the cipher (7068118) and time (76e26f8) round-trip doctest pattern on **phenotype-config-core** (`libs/phenotype-config-core/`), which previously had no executable examples.

## Changes

- `libs/phenotype-config-core/src/lib.rs` — adds 6 doctests (132 insertions) covering the full public surface.

## Doctests added

| Location | What it covers |
| --- | --- |
| `lib.rs` quick-start | `ConfigLoader::load_from` on a tempfile-backed TOML with a Deserialize struct |
| `ConfigError` | `NotFound` + `Io` Display outputs |
| `ConfigLoader::new` | `search_paths()` populated, `name()` round-trips |
| `ConfigLoader::with_path` | custom path is inserted, original cwd entry remains last |
| `ConfigLoader::load` | `NotFound` case on a name with no on-disk entries |
| `ConfigLoader::load_from` | full Deserialize struct round-trip on a fixed TOML payload |

All examples use fixed/seeded values (no `now()`, `random`, or `uuid::new_v4()` patterns); tempfiles come from the existing `tempfile` dev-dependency.

## Verification

```
$ cargo test -p phenotype-config-core --doc
running 6 tests
test libs/phenotype-config-core/src/lib.rs - ConfigLoader::new (line 85) ... ok
test libs/phenotype-config-core/src/lib.rs - ConfigLoader::load (line 147) ... ok
test libs/phenotype-config-core/src/lib.rs - ConfigError (line 42) ... ok
test libs/phenotype-config-core/src/lib.rs - ConfigLoader::with_path (line 120) ... ok
test libs/phenotype-config-core/src/lib.rs - ConfigLoader::load_from (line 179) ... ok
test libs/phenotype-config-core/src/lib.rs - (line 13) ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ RUSTDOCFLAGS=-D warnings cargo doc -p phenotype-config-core --no-deps
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.83s
   Generated .../target/doc/phenotype_config_core/index.html

$ cargo clippy -p phenotype-config-core --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 41.51s
```

## Why phenotype-config-core (and not phenotype-logging)

The task allowed falling back to any crate with a public API and no doctests if the preferred `phenotype-log` was not stable/exposed. `crates/phenotype-logging/` is the only `phenotype-log*` crate in the workspace, but its `config.rs`, `subscriber.rs`, and `otel.rs` source files are orphaned — they are not declared as modules in `lib.rs`, so the only public surface is the minimal `Error`/`Result` pair, which is too small for a meaningful 3-5 doctest sweep. `phenotype-config-core` (`libs/phenotype-config-core/`) is the workspace member with a real public API (`ConfigError`, `ConfigLoader` with `new`/`with_path`/`load`/`load_from`/`search_paths`/`name`) and zero existing doctests.

Related: 7068118 cipher round-trip doctests
Related: 76e26f8 time round-trip doctests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doctest-only changes; config loading logic is unchanged.
> 
> **Overview**
> Adds **documentation-only** coverage to `phenotype-config-core`: a crate-level **Quick start**, rustdoc on `ConfigError` and `ConfigLoader` methods, and **six executable doctests** that mirror the cipher/time round-trip pattern elsewhere in HexaKit.
> 
> The new examples exercise **`ConfigLoader::load_from`** and **`load`** (including **`ConfigError::NotFound`**), **`new`** / **`search_paths`** / **`name`**, **`with_path`** ordering vs the cwd entry, and **`ConfigError`** display strings—using **tempfiles** and fixed TOML payloads rather than nondeterministic values. The module doc now links custom paths via [`ConfigLoader::with_path`] instead of plain backticks.
> 
> **No loader behavior or public API semantics change**; this is rustdoc + `cargo test --doc` validation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87956f587400bffbd1994722d7b1a9e76e4ff5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add executable examples for config loading and error handling**

### What Changed
- Added quick-start examples that show how to load a config file from a known path and turn it into a typed struct
- Added examples for the main loader behavior: default search order, adding a custom path, and the not-found result when no config file exists
- Added examples for error messages so config failures are easier to understand from the output
- Clarified the public docs to explain how the loader searches for config files and when to use direct file loading

### Impact
`✅ Easier first-time setup`
`✅ Clearer config error messages`
`✅ Fewer surprises about config search order`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
