### PR TITLE
chore(HexaKit): add round-trip doctests to phenotype-state-machine

### DIFF
--- a/crates/phenotype-state-machine/src/lib.rs
+++ b/crates/phenotype-state-machine/src/lib.rs
@@ -1,4 +1,30 @@
 //! Generic finite state machine with transition guards and callbacks.
+//!
+//! ## Quick start
+//!
+//! Build a traffic-light style state machine, send a single event,
+//! and inspect the new state:
+//!
+//! ```
+//! use phenotype_state_machine::StateMachineBuilder;
+//!
+//! let sm = StateMachineBuilder::new("red")
+//!     .transition("red", "next", "green")
+//!     .transition("green", "next", "yellow")
+//!     .transition("yellow", "next", "red")
+//!     .build()
+//!     .unwrap();
+//!
+//! assert_eq!(sm.current(), "red");
+//! let landed = sm.send("next").unwrap();
+//! assert_eq!(landed, "green");
+//! assert_eq!(sm.current(), "green");
+//!
+//! // `can_send` reports whether an event is wired from the current state,
+//! // and `available_events` returns every wired event.
+//! assert!(sm.can_send("next"));
+//! assert_eq!(sm.available_events(), vec!["next".to_string()]);
+//! ```
 
 use std::collections::HashMap;
 use std::fmt;
@@ -12,6 +38,47 @@ type StateCallback = Arc<dyn Fn(&str) + Send + Sync>;
 type TransitionGuard = Box<dyn Fn(&str, &str) -> bool + Send + Sync>;
 
 /// Errors that can occur during state machine operations.
+///
+/// Each variant has a stable `Display` rendering suitable for logs
+/// and error messages.
+///
+/// # Examples
+///
+/// ```
+/// use phenotype_state_machine::StateMachineError;
+///
+/// // No transition is registered for the (state, event) pair.
+/// let invalid = StateMachineError::InvalidTransition {
+///     from: "red".to_string(),
+///     event: "fly".to_string(),
+/// };
+/// assert_eq!(
+///     invalid.to_string(),
+///     "invalid transition: no transition from 'red' on event 'fly'",
+/// );
+///
+/// // The transition exists but its guard returned `false`.
+/// let rejected = StateMachineError::GuardRejected {
+///     from: "locked".to_string(),
+///     event: "unlock".to_string(),
+/// };
+/// assert_eq!(
+///     rejected.to_string(),
+///     "transition from 'locked' on 'unlock' rejected by guard",
+/// );
+///
+/// // The state is not present in the transition table.
+/// assert_eq!(
+///     StateMachineError::UnknownState("ghost".to_string()).to_string(),
+///     "unknown state: 'ghost'",
+/// );
+///
+/// // The builder rejected the configuration.
+/// assert_eq!(
+///     StateMachineError::BuildError("initial state cannot be empty".to_string()).to_string(),
+///     "builder error: initial state cannot be empty",
+/// );
+/// ```
 #[derive(Debug, Clone, Error)]
 pub enum StateMachineError {
     #[error("invalid transition: no transition from '{from}' on event '{event}'")]
@@ -55,6 +122,27 @@ impl Default for StateMachine {
 
 impl StateMachine {
     /// Create a new empty state machine.
+    ///
+    /// The initial state is the empty string; the machine has no
+    /// transitions, no guards, and no callbacks. Use
+    /// [`StateMachineBuilder`] for the common case where transitions
+    /// are known up front.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_state_machine::{StateMachine, StateMachineError};
+    ///
+    /// // `new` and `default` produce the same empty machine.
+    /// let sm = StateMachine::new();
+    /// assert_eq!(sm.current(), "");
+    /// assert!(!sm.can_send("any"));
+    /// assert!(sm.available_events().is_empty());
+    ///
+    /// // Sending an event with no transitions is `InvalidTransition`.
+    /// let err = sm.send("any").unwrap_err();
+    /// assert!(matches!(err, StateMachineError::InvalidTransition { .. }));
+    /// ```
     pub fn new() -> Self {
         Self {
             current: RwLock::new(String::new()),
@@ -70,6 +158,47 @@ impl StateMachine {
     }
 
     /// Send an event to the state machine, potentially triggering a transition.
+    ///
+    /// On success, returns the new state. The current state is updated
+    /// as a side effect. If the (state, event) pair has no registered
+    /// transition, returns
+    /// [`StateMachineError::InvalidTransition`]; if a transition is
+    /// registered but its guard returned `false`, returns
+    /// [`StateMachineError::GuardRejected`]. `on_exit` callbacks fire
+    /// for the old state and `on_enter` callbacks fire for the new
+    /// state before the new state is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_state_machine::{StateMachineBuilder, StateMachineError};
+    ///
+    /// // The guard on "running -> idle" always returns `false`, so every
+    /// // `stop` event hits the guard; `halt` is not in the table at all.
+    /// let sm = StateMachineBuilder::new("idle")
+    ///     .transition("idle", "go", "running")
+    ///     .guarded_transition("running", "stop", "idle", |_from, _event| false)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // Happy path: returns the new state and updates `current()`.
+    /// assert_eq!(sm.send("go").unwrap(), "running");
+    /// assert_eq!(sm.current(), "running");
+    ///
+    /// // Unknown event from the current state: `InvalidTransition`.
+    /// assert!(matches!(
+    ///     sm.send("halt").unwrap_err(),
+    ///     StateMachineError::InvalidTransition { .. }
+    /// ));
+    ///
+    /// // Registered event whose guard rejects: `GuardRejected`, and the
+    /// // state is unchanged.
+    /// assert!(matches!(
+    ///     sm.send("stop").unwrap_err(),
+    ///     StateMachineError::GuardRejected { .. }
+    /// ));
+    /// assert_eq!(sm.current(), "running");
+    /// ```
     pub fn send(&self, event: &str) -> Result<String> {
         let mut current = self.current.write().unwrap();
         let key = (current.clone(), event.to_string());
@@ -152,6 +281,37 @@ pub struct StateMachineBuilder {
 
 impl StateMachineBuilder {
     /// Create a new builder with the given initial state.
+    ///
+    /// `build` returns a [`StateMachine`] whose `current()` is the
+    /// supplied initial state and whose transition table is the union
+    /// of every [`transition`](Self::transition) /
+    /// [`guarded_transition`](Self::guarded_transition) call. An empty
+    /// initial state is rejected with
+    /// [`StateMachineError::BuildError`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_state_machine::{StateMachineBuilder, StateMachineError};
+    ///
+    /// // Three transitions in a triangle.
+    /// let sm = StateMachineBuilder::new("a")
+    ///     .transition("a", "next", "b")
+    ///     .transition("b", "next", "c")
+    ///     .transition("c", "next", "a")
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// sm.send("next").unwrap();
+    /// sm.send("next").unwrap();
+    /// assert_eq!(sm.current(), "c");
+    /// sm.send("next").unwrap();
+    /// assert_eq!(sm.current(), "a");
+    ///
+    /// // The initial state must be non-empty.
+    /// let err = StateMachineBuilder::new("").build().unwrap_err();
+    /// assert!(matches!(err, StateMachineError::BuildError(_)));
+    /// ```
     pub fn new(initial: &str) -> Self {
         Self {
             initial: initial.to_string(),
@@ -174,6 +334,39 @@ impl StateMachineBuilder {
     }
 
     /// Add a guarded transition.
+    ///
+    /// The guard receives `(&from_state, &event)` and returns `true`
+    /// to allow the transition or `false` to reject it. A rejected
+    /// transition leaves the current state unchanged and returns
+    /// [`StateMachineError::GuardRejected`]. An event with no
+    /// registered transition at all is a different error,
+    /// [`StateMachineError::InvalidTransition`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phenotype_state_machine::{StateMachineBuilder, StateMachineError};
+    ///
+    /// // Two parallel machines: one with a permissive guard, one with
+    /// // a rejecting guard, both on the same (state, event) pair.
+    /// let sm_ok = StateMachineBuilder::new("locked")
+    ///     .guarded_transition("locked", "open", "unlocked", |_from, _event| true)
+    ///     .build()
+    ///     .unwrap();
+    /// let sm_blocked = StateMachineBuilder::new("locked")
+    ///     .guarded_transition("locked", "open", "unlocked", |_from, _event| false)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // Permissive guard: the transition fires.
+    /// assert_eq!(sm_ok.send("open").unwrap(), "unlocked");
+    /// assert_eq!(sm_ok.current(), "unlocked");
+    ///
+    /// // Rejecting guard: returns `GuardRejected` and the state is unchanged.
+    /// let err = sm_blocked.send("open").unwrap_err();
+    /// assert!(matches!(err, StateMachineError::GuardRejected { .. }));
+    /// assert_eq!(sm_blocked.current(), "locked");
+    /// ```
     pub fn guarded_transition(
         mut self,
         from: &str,
@@ -192,6 +385,35 @@ impl StateMachineBuilder {
     }
 
     /// Register a callback for when a state is entered.
+    ///
+    /// `on_enter` callbacks are invoked once per state entry with the
+    /// new state's name as the argument. They fire after the guard
+    /// has accepted the transition and after `on_exit` callbacks for
+    /// the previous state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    /// use phenotype_state_machine::StateMachineBuilder;
+    ///
+    /// // Count entries into "b" using a shared `AtomicUsize`.
+    /// let counter = Arc::new(AtomicUsize::new(0));
+    /// let counter_for_cb = counter.clone();
+    /// let sm = StateMachineBuilder::new("a")
+    ///     .transition("a", "go", "b")
+    ///     .on_enter("b", move |_state| {
+    ///         counter_for_cb.fetch_add(1, Ordering::SeqCst);
+    ///     })
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // First entry fires the callback.
+    /// sm.send("go").unwrap();
+    /// assert_eq!(counter.load(Ordering::SeqCst), 1);
+    /// assert_eq!(sm.current(), "b");
+    /// ```
     pub fn on_enter(
         mut self,
         state: &str,
@@ -205,6 +427,38 @@ impl StateMachineBuilder {
     }
 
     /// Register a callback for when a state is exited.
+    ///
+    /// `on_exit` callbacks receive the old state's name and are
+    /// invoked once per state exit, before `on_enter` callbacks for
+    /// the next state. They do not fire for a rejected transition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    /// use phenotype_state_machine::StateMachineBuilder;
+    ///
+    /// // Count exits from "a".
+    /// let exits = Arc::new(AtomicUsize::new(0));
+    /// let exits_for_cb = exits.clone();
+    /// let sm = StateMachineBuilder::new("a")
+    ///     .transition("a", "go", "b")
+    ///     .on_exit("a", move |_state| {
+    ///         exits_for_cb.fetch_add(1, Ordering::SeqCst);
+    ///     })
+    ///     .guarded_transition("b", "back", "a", |_, _| true)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // "a" -> "b" fires the exit hook once.
+    /// sm.send("go").unwrap();
+    /// assert_eq!(exits.load(Ordering::SeqCst), 1);
+    ///
+    /// // "b" -> "a" does not fire the "a" exit hook (it's an entry).
+    /// sm.send("back").unwrap();
+    /// assert_eq!(exits.load(Ordering::SeqCst), 1);
+    /// ```
     pub fn on_exit(mut self, state: &str, callback: impl Fn(&str) + Send + Sync + 'static) -> Self {
         self.on_exit
             .entry(state.to_string())


### PR DESCRIPTION
## **User description**
## Summary

Continues the cipher (7068118), time (76e26f8), and config-core (87956f5) doctest pattern on **phenotype-state-machine**, which previously had no executable examples.

The crate is a clean target for this pattern: the public API (`StateMachine`, `StateMachineBuilder`, `StateMachineError`) is fully deterministic (no I/O, time, randomness, or global-state mutation), so every doctest uses fixed/seeded values and is reproducible across runs.

## Changes

- 1 file changed, 254 insertions(+)
- Adds 8 doctests covering the public surface:
  - `lib.rs` quick-start: traffic-light builder, send, current, can_send, available_events
  - `StateMachineError`: `Display` output for all 4 variants (InvalidTransition, GuardRejected, UnknownState, BuildError)
  - `StateMachine::new`: empty machine, send error path
  - `StateMachine::send`: happy path, `InvalidTransition` (no entry in table), `GuardRejected` (registered entry, rejecting guard)
  - `StateMachineBuilder::new`: triangular transition table plus empty-initial `BuildError`
  - `StateMachineBuilder::guarded_transition`: permissive and rejecting guards on the same (state, event) pair
  - `StateMachineBuilder::on_enter`: shared `AtomicUsize` counter fires on entry
  - `StateMachineBuilder::on_exit`: shared `AtomicUsize` counter fires on exit, not on reverse-entry

## Note on phenotype-log (phenotype-logging)

`phenotype-log` (`phenotype-logging`) was the first choice per the task, but its public API is just `Error` and `Result` (the `config`, `subscriber`, and `otel` modules are not declared in `lib.rs`, so they are crate-private and have no public surface to exercise). `phenotype-state-machine` was the next-best candidate with a rich, stable, fully-deterministic public API and zero doctests.

## Verification

```
cargo test -p phenotype-state-machine --doc   -> 8 passed
cargo test -p phenotype-state-machine        -> 10 unit + 8 doctests passed
RUSTDOCFLAGS=-D warnings cargo doc -p phenotype-state-machine --no-deps -> clean
cargo clippy -p phenotype-state-machine --all-targets -- -D warnings -> clean
```

## Related

- 7068118 cipher round-trip doctests
- 76e26f8 time round-trip doctests
- 87956f5 config-core round-trip doctests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doctest-only changes; no production logic modified.
> 
> **Overview**
> Adds **documentation-only** coverage to `phenotype-state-machine` in `lib.rs`, following the same round-trip doctest pattern used on cipher, time, and config-core. **No runtime or API behavior changes.**
> 
> A **Quick start** section at the crate root documents a traffic-light builder flow with `send`, `current`, `can_send`, and `available_events`. **Eight executable doctests** exercise the public surface: error `Display` strings for all `StateMachineError` variants; empty `StateMachine::new` and failed `send`; `send` success vs `InvalidTransition` vs `GuardRejected`; triangular `StateMachineBuilder::new` / empty-initial `BuildError`; permissive vs rejecting `guarded_transition`; and `on_enter` / `on_exit` hooks verified with `AtomicUsize` counters.
> 
> Prose rustdoc was added alongside those examples for `StateMachineError`, `StateMachine::new`, `StateMachine::send`, and the builder methods (`new`, `guarded_transition`, `on_enter`, `on_exit`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07809f12679b26691031c191529ae00d3657b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add executable examples for the state machine public API**

### What Changed
- Added quick-start examples for building a simple state machine, sending events, and checking the current state and available events
- Added examples that show each error case and the expected message format
- Added examples for creating machines, handling successful and rejected transitions, and using entry and exit callbacks

### Impact
`✅ Easier first-time use`
`✅ Clearer error messages`
`✅ Fewer setup mistakes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
