### PR TITLE
chore(governance): add missing governance files

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,39 @@
+name: Governance Baseline Audit
+
+on:
+  schedule:
+    - cron: '23 4 * * 1'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  governance-audit:
+    name: L1.4 Governance baseline audit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify governance baseline files
+        run: |
+          set -euo pipefail
+          missing=()
+          for f in .github/workflows/scorecard.yml \
+                   .github/workflows/governance.yml \
+                   .github/dependabot.yml \
+                   SECURITY.md \
+                   cliff.toml; do
+            if [ ! -f "$f" ]; then
+              missing+=("$f")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing L1.4 governance baseline files: ${missing[*]}"
+            exit 1
+          fi
+          echo "L1.4 Governance Baseline Audit passed"
+          echo "All required governance files are present."

--- a/Metron/src/adapters/prometheus.rs
+++ b/Metron/src/adapters/prometheus.rs
@@ -1,15 +1,15 @@
 //! Prometheus Adapter
 
-use std::net::SocketAddr;
+use bytes::Bytes;
+use http_body_util::Full;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Request, Response, header::CONTENT_TYPE};
+use hyper::{header::CONTENT_TYPE, Request, Response};
 use hyper_util::rt::TokioIo;
+use std::net::SocketAddr;
 use tokio::net::TcpListener;
-use http_body_util::Full;
-use bytes::Bytes;
 
-use crate::application::{PrometheusExporter, exporter::MetricExporter};
+use crate::application::{exporter::MetricExporter, PrometheusExporter};
 use crate::domain::Registry;
 
 /// Start Prometheus metrics endpoint
@@ -35,17 +35,16 @@ pub async fn start_prometheus_server(
                 let exporter = exporter.clone();
                 async move {
                     let metrics = exporter.export(&registry).unwrap_or_default();
-                    Ok::<_, std::convert::Infallible>(Response::builder()
-                        .header(CONTENT_TYPE, "text/plain; version=0.0.4")
-                        .body(Full::new(Bytes::from(metrics)))
-                        .unwrap())
+                    Ok::<_, std::convert::Infallible>(
+                        Response::builder()
+                            .header(CONTENT_TYPE, "text/plain; version=0.0.4")
+                            .body(Full::new(Bytes::from(metrics)))
+                            .unwrap(),
+                    )
                 }
             });
 
-            if let Err(e) = http1::Builder::new()
-                .serve_connection(io, svc)
-                .await
-            {
+            if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
                 eprintln!("Error serving connection: {e}");
             }
         });

--- a/Metron/src/domain/counter.rs
+++ b/Metron/src/domain/counter.rs
@@ -1,8 +1,8 @@
 //! Counter Metric
 
-use std::sync::Arc;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use super::{MetricMetadata, MetricType};
 

--- a/Metron/src/domain/gauge.rs
+++ b/Metron/src/domain/gauge.rs
@@ -1,8 +1,8 @@
 //! Gauge Metric
 
-use std::sync::Arc;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use super::{MetricMetadata, MetricType};
 

--- a/Metron/src/domain/histogram.rs
+++ b/Metron/src/domain/histogram.rs
@@ -1,8 +1,8 @@
 //! Histogram Metric
 
-use std::sync::Arc;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use super::{MetricMetadata, MetricType};
 
@@ -67,7 +67,12 @@ pub struct Histogram {
 impl Histogram {
     /// Create with default buckets
     pub fn new(name: impl Into<String>) -> Self {
-        Self::with_buckets(name, vec![0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0])
+        Self::with_buckets(
+            name,
+            vec![
+                0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+            ],
+        )
     }
 
     /// Create with custom buckets

--- a/Metron/src/domain/mod.rs
+++ b/Metron/src/domain/mod.rs
@@ -1,15 +1,15 @@
 //! Domain Layer
 
-pub mod metric;
 pub mod counter;
+pub mod errors;
 pub mod gauge;
 pub mod histogram;
+pub mod metric;
 pub mod registry;
-pub mod errors;
 
-pub use metric::*;
 pub use counter::*;
+pub use errors::*;
 pub use gauge::*;
 pub use histogram::*;
+pub use metric::*;
 pub use registry::*;
-pub use errors::*;

--- a/Metron/src/domain/registry.rs
+++ b/Metron/src/domain/registry.rs
@@ -1,7 +1,7 @@
 //! Metric Registry
 
-use std::collections::HashMap;
 use parking_lot::RwLock;
+use std::collections::HashMap;
 
 use super::{Counter, Gauge, Histogram, MetricError};
 
@@ -72,7 +72,11 @@ impl Registry {
     }
 
     /// Register a histogram
-    pub fn register_histogram(&self, name: &str, bounds: Vec<f64>) -> Result<Histogram, MetricError> {
+    pub fn register_histogram(
+        &self,
+        name: &str,
+        bounds: Vec<f64>,
+    ) -> Result<Histogram, MetricError> {
         let histogram = Histogram::with_buckets(name, bounds);
         let mut histograms = self.histograms.write();
         if histograms.contains_key(name) {

--- a/Metron/src/lib.rs
+++ b/Metron/src/lib.rs
@@ -1,8 +1,8 @@
 //! # metrickit - Metrics Collection Framework
 
-pub mod domain;
-pub mod application;
 pub mod adapters;
+pub mod application;
+pub mod domain;
 
-pub use domain::*;
 pub use application::*;
+pub use domain::*;

--- a/Metron/tests/lib_tests.rs
+++ b/Metron/tests/lib_tests.rs
@@ -1,13 +1,11 @@
 //! Unit tests for Metron domain and application layers.
 #![allow(clippy::approx_constant)] // -3.14 is an arbitrary test value, not PI
 
+use metrickit::application::{MetricExporter, PrometheusExporter};
 use metrickit::domain::{
-    Counter, CounterValue, Gauge, GaugeValue,
-    Histogram, HistogramBuckets, HistogramValue,
-    MetricMetadata, MetricType, MetricError,
-    Registry,
+    Counter, CounterValue, Gauge, GaugeValue, Histogram, HistogramBuckets, HistogramValue,
+    MetricError, MetricMetadata, MetricType, Registry,
 };
-use metrickit::application::{PrometheusExporter, MetricExporter};
 
 // ============================================================================
 // CounterValue Tests
@@ -66,9 +64,11 @@ mod counter {
 
     #[test]
     fn with_description_sets_metadata() {
-        let c = Counter::new("http_requests")
-            .with_description("Total HTTP requests");
-        assert_eq!(c.metadata().description.as_deref(), Some("Total HTTP requests"));
+        let c = Counter::new("http_requests").with_description("Total HTTP requests");
+        assert_eq!(
+            c.metadata().description.as_deref(),
+            Some("Total HTTP requests")
+        );
     }
 
     #[test]
@@ -109,7 +109,9 @@ mod counter {
 
     #[test]
     fn metadata_returns_metadata() {
-        let c = Counter::new("meta_test").with_description("desc").with_unit("ms");
+        let c = Counter::new("meta_test")
+            .with_description("desc")
+            .with_unit("ms");
         let m = c.metadata();
         assert_eq!(m.name, "meta_test");
         assert_eq!(m.description.as_deref(), Some("desc"));
@@ -176,7 +178,10 @@ mod gauge {
     #[test]
     fn with_description_sets_description() {
         let g = Gauge::new("memory_bytes").with_description("RSS memory usage");
-        assert_eq!(g.metadata().description.as_deref(), Some("RSS memory usage"));
+        assert_eq!(
+            g.metadata().description.as_deref(),
+            Some("RSS memory usage")
+        );
     }
 
     #[test]
@@ -232,9 +237,9 @@ mod histogram_buckets {
     fn observe_increments_correct_bucket() {
         let mut hb = HistogramBuckets::new(vec![0.1, 0.5, 1.0]);
         hb.observe(0.05); // below first bucket
-        hb.observe(0.3);  // in first bucket (0.1)
-        hb.observe(0.7);  // in second bucket (0.5)
-        hb.observe(2.0);   // in overflow bucket (inf)
+        hb.observe(0.3); // in first bucket (0.1)
+        hb.observe(0.7); // in second bucket (0.5)
+        hb.observe(2.0); // in overflow bucket (inf)
         assert_eq!(hb.counts, vec![1, 1, 1, 1]);
     }
 
@@ -284,7 +289,10 @@ mod histogram {
     fn new_uses_default_buckets() {
         let h = Histogram::new("latency");
         let val = h.get();
-        assert_eq!(val.buckets.bounds, vec![0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]);
+        assert_eq!(
+            val.buckets.bounds,
+            vec![0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+        );
     }
 
     #[test]
@@ -297,7 +305,10 @@ mod histogram {
     #[test]
     fn with_description_sets_description() {
         let h = Histogram::new("req_duration").with_description("Request duration");
-        assert_eq!(h.metadata().description.as_deref(), Some("Request duration"));
+        assert_eq!(
+            h.metadata().description.as_deref(),
+            Some("Request duration")
+        );
     }
 
     #[test]
@@ -338,15 +349,13 @@ mod metric_metadata {
 
     #[test]
     fn with_description_returns_new_instance() {
-        let m = MetricMetadata::new("x", MetricType::Gauge)
-            .with_description("A gauge");
+        let m = MetricMetadata::new("x", MetricType::Gauge).with_description("A gauge");
         assert_eq!(m.description.as_deref(), Some("A gauge"));
     }
 
     #[test]
     fn with_unit_returns_new_instance() {
-        let m = MetricMetadata::new("y", MetricType::Counter)
-            .with_unit("bytes");
+        let m = MetricMetadata::new("y", MetricType::Counter).with_unit("bytes");
         assert_eq!(m.unit.as_deref(), Some("bytes"));
     }
 

--- a/Traceon/src/application/tracer_provider.rs
+++ b/Traceon/src/application/tracer_provider.rs
@@ -1,7 +1,7 @@
 //! Tracer Provider - Use Case
 
-use std::sync::Arc;
 use async_trait::async_trait;
+use std::sync::Arc;
 
 use crate::domain::*;
 
@@ -61,9 +61,7 @@ impl TracerProvider {
     }
 
     pub fn tracer(&self) -> TracerInstance<'_> {
-        TracerInstance {
-            provider: self,
-        }
+        TracerInstance { provider: self }
     }
 
     pub async fn shutdown(&self) -> TraceResult<()> {
@@ -88,7 +86,9 @@ impl<'a> Tracer for TracerInstance<'a> {
     }
 
     fn span_with_kind(&self, name: &str, kind: SpanKind) -> Box<dyn SpanHandle> {
-        Box::new(ActiveSpan::new(Span::new(name, uuid::Uuid::new_v4()).with_kind(kind)))
+        Box::new(ActiveSpan::new(
+            Span::new(name, uuid::Uuid::new_v4()).with_kind(kind),
+        ))
     }
 
     fn name(&self) -> &str {

--- a/Traceon/src/domain/context.rs
+++ b/Traceon/src/domain/context.rs
@@ -14,7 +14,10 @@ impl W3CTraceContext {
         let flags = if sampled { "01" } else { "00" };
         // W3C traceparent: 00-<32hex trace-id>-<16hex parent-id>-<2hex flags>
         let tid = format!("{:032x}", trace_id.as_u128());
-        let sid = format!("{:016x}", (span_id.as_u128() & 0xFFFF_FFFF_FFFF_FFFF) as u64);
+        let sid = format!(
+            "{:016x}",
+            (span_id.as_u128() & 0xFFFF_FFFF_FFFF_FFFF) as u64
+        );
         let traceparent = format!("00-{tid}-{sid}-{flags}");
         Self { traceparent }
     }
@@ -43,7 +46,10 @@ impl B3Context {
     pub fn new(trace_id: Uuid, span_id: Uuid, sampled: bool) -> Self {
         Self {
             trace_id: Some(format!("{:032x}", trace_id.as_u128())),
-            span_id: Some(format!("{:016x}", (span_id.as_u128() & 0xFFFF_FFFF_FFFF_FFFF) as u64)),
+            span_id: Some(format!(
+                "{:016x}",
+                (span_id.as_u128() & 0xFFFF_FFFF_FFFF_FFFF) as u64
+            )),
             sampled: Some(sampled),
         }
     }

--- a/Traceon/src/domain/mod.rs
+++ b/Traceon/src/domain/mod.rs
@@ -1,13 +1,13 @@
 //! Domain Layer
 
+pub mod context;
+pub mod errors;
 pub mod span;
 pub mod trace;
-pub mod context;
 pub mod tracer;
-pub mod errors;
 
+pub use context::*;
+pub use errors::*;
 pub use span::*;
 pub use trace::*;
-pub use context::*;
 pub use tracer::*;
-pub use errors::*;

--- a/Traceon/src/domain/span.rs
+++ b/Traceon/src/domain/span.rs
@@ -1,8 +1,8 @@
 //! Span - Domain Entity
 
-use std::sync::Mutex;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
 use uuid::Uuid;
 
 /// Span ID
@@ -114,23 +114,33 @@ pub enum AttributeValue {
 }
 
 impl From<String> for AttributeValue {
-    fn from(s: String) -> Self { AttributeValue::String(s) }
+    fn from(s: String) -> Self {
+        AttributeValue::String(s)
+    }
 }
 
 impl From<&str> for AttributeValue {
-    fn from(s: &str) -> Self { AttributeValue::String(s.to_string()) }
+    fn from(s: &str) -> Self {
+        AttributeValue::String(s.to_string())
+    }
 }
 
 impl From<i64> for AttributeValue {
-    fn from(n: i64) -> Self { AttributeValue::I64(n) }
+    fn from(n: i64) -> Self {
+        AttributeValue::I64(n)
+    }
 }
 
 impl From<f64> for AttributeValue {
-    fn from(f: f64) -> Self { AttributeValue::F64(f) }
+    fn from(f: f64) -> Self {
+        AttributeValue::F64(f)
+    }
 }
 
 impl From<bool> for AttributeValue {
-    fn from(b: bool) -> Self { AttributeValue::Bool(b) }
+    fn from(b: bool) -> Self {
+        AttributeValue::Bool(b)
+    }
 }
 
 /// Span event

--- a/Traceon/src/domain/trace.rs
+++ b/Traceon/src/domain/trace.rs
@@ -1,7 +1,7 @@
 //! Trace - Domain Entity
 
-use uuid::Uuid;
 use chrono::{DateTime, Utc};
+use uuid::Uuid;
 
 use super::Span;
 

--- a/Traceon/src/domain/tracer.rs
+++ b/Traceon/src/domain/tracer.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 
-use super::{SpanKind, SpanContext};
+use super::{SpanContext, SpanKind};
 
 /// Tracer trait - primary port
 #[async_trait]

--- a/Traceon/src/lib.rs
+++ b/Traceon/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! Zero-cost distributed tracing with OpenTelemetry support.
 
-pub mod domain;
-pub mod application;
 pub mod adapters;
+pub mod application;
+pub mod domain;
 pub mod infrastructure;
 
-pub use domain::*;
 pub use application::*;
+pub use domain::*;

--- a/crates/phenotype-analytics/src/client.rs
+++ b/crates/phenotype-analytics/src/client.rs
@@ -13,7 +13,7 @@ impl<B: AnalyticsBackend> AnalyticsClient<B> {
     pub fn new(backend: B) -> Self {
         Self { backend }
     }
-    
+
     /// Track an event
     pub async fn track(&self, event: AnalyticsEvent) -> Result<()> {
         self.backend.track(event).await

--- a/crates/phenotype-analytics/src/event.rs
+++ b/crates/phenotype-analytics/src/event.rs
@@ -19,12 +19,12 @@ impl AnalyticsEvent {
             timestamp: chrono::Utc::now().to_rfc3339(),
         }
     }
-    
+
     pub fn with_property(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.properties.insert(key.into(), value.into());
         self
     }
-    
+
     pub fn with_user_id(mut self, user_id: impl Into<String>) -> Self {
         self.user_id = Some(user_id.into());
         self

--- a/crates/phenotype-analytics/src/lib.rs
+++ b/crates/phenotype-analytics/src/lib.rs
@@ -1,11 +1,11 @@
 //! Analytics framework
 
+pub mod client;
 pub mod error;
 pub mod event;
-pub mod client;
 pub mod traits;
 
+pub use client::AnalyticsClient;
 pub use error::{AnalyticsError, Result};
 pub use event::AnalyticsEvent;
-pub use client::AnalyticsClient;
 pub use traits::Trackable;

--- a/crates/phenotype-bdd/src/steps.rs
+++ b/crates/phenotype-bdd/src/steps.rs
@@ -27,7 +27,10 @@ impl StepContext {
 
     /// Get a value from the context
     pub fn get<T: Any + Clone>(&self, key: &str) -> Option<T> {
-        self.data.get(key).and_then(|v| v.downcast_ref::<T>()).cloned()
+        self.data
+            .get(key)
+            .and_then(|v| v.downcast_ref::<T>())
+            .cloned()
     }
 
     /// Get a reference to a value in the context

--- a/crates/phenotype-config-loader/src/lib.rs
+++ b/crates/phenotype-config-loader/src/lib.rs
@@ -32,7 +32,10 @@ mod tests {
     use serde::Deserialize;
 
     #[derive(Deserialize, Debug, PartialEq)]
-    struct TestConfig { name: String, value: i32 }
+    struct TestConfig {
+        name: String,
+        value: i32,
+    }
 
     #[test]
     fn test_load_json() {

--- a/crates/phenotype-contract-tests/src/contract.rs
+++ b/crates/phenotype-contract-tests/src/contract.rs
@@ -30,7 +30,7 @@ impl Contract {
     pub fn new() -> Self {
         Self { tests: Vec::new() }
     }
-    
+
     pub fn add_test(&mut self, test: ContractTest) {
         self.tests.push(test);
     }

--- a/crates/phenotype-core/src/lib.rs
+++ b/crates/phenotype-core/src/lib.rs
@@ -76,7 +76,7 @@ pub mod error {
 
 /// Configuration re-exports
 pub mod config {
-    pub use phenotype_config_core::{ConfigLoader};
+    pub use phenotype_config_core::ConfigLoader;
 }
 
 /// Event bus re-exports
@@ -126,7 +126,7 @@ pub mod state_machine {
 
 /// Policy engine re-exports
 pub mod policy {
-    pub use phenotype_policy_engine::{PolicyEngine, PolicyResult, Policy, Rule};
+    pub use phenotype_policy_engine::{Policy, PolicyEngine, PolicyResult, Rule};
 }
 
 /// Cache re-exports
@@ -145,9 +145,7 @@ pub mod time {
 }
 
 /// HTTP client re-exports
-pub mod http {
-    
-}
+pub mod http {}
 
 /// External crate re-exports for convenience
 pub mod external {

--- a/crates/phenotype-cost-core/src/lib.rs
+++ b/crates/phenotype-cost-core/src/lib.rs
@@ -127,9 +127,18 @@ mod tests {
 
     #[test]
     fn test_complexity_compare() {
-        assert_eq!(Complexity::compare(Complexity::Constant, Complexity::Linear), Ordering::Less);
-        assert_eq!(Complexity::compare(Complexity::Quadratic, Complexity::Linear), Ordering::Greater);
-        assert_eq!(Complexity::compare(Complexity::Linear, Complexity::Linear), Ordering::Equal);
+        assert_eq!(
+            Complexity::compare(Complexity::Constant, Complexity::Linear),
+            Ordering::Less
+        );
+        assert_eq!(
+            Complexity::compare(Complexity::Quadratic, Complexity::Linear),
+            Ordering::Greater
+        );
+        assert_eq!(
+            Complexity::compare(Complexity::Linear, Complexity::Linear),
+            Ordering::Equal
+        );
     }
 
     #[test]
@@ -196,7 +205,10 @@ mod tests {
     #[test]
     fn test_complexity_description() {
         assert_eq!(Complexity::Constant.description(), "O(1) - Constant time");
-        assert_eq!(Complexity::Quadratic.description(), "O(n²) - Quadratic time");
+        assert_eq!(
+            Complexity::Quadratic.description(),
+            "O(n²) - Quadratic time"
+        );
     }
 
     #[test]

--- a/crates/phenotype-error-core/src/lib.rs
+++ b/crates/phenotype-error-core/src/lib.rs
@@ -214,6 +214,15 @@ impl From<serde_json::Error> for ConfigError {
     }
 }
 
+impl From<std::num::ParseIntError> for ConfigError {
+    fn from(err: std::num::ParseIntError) -> Self {
+        Self::Parse {
+            format: "int".into(),
+            reason: err.to_string(),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Storage / raw I/O layer
 // ---------------------------------------------------------------------------
@@ -366,6 +375,13 @@ mod tests {
         let json_err = serde_json::from_str::<String>("bad").unwrap_err();
         let cfg_err = ConfigError::from(json_err);
         assert!(matches!(cfg_err, ConfigError::Parse { format, .. } if format == "json"));
+    }
+
+    #[test]
+    fn config_error_from_parse_int() {
+        let int_err = "not_a_number".parse::<i64>().unwrap_err();
+        let cfg_err = ConfigError::from(int_err);
+        assert!(matches!(cfg_err, ConfigError::Parse { format, .. } if format == "int"));
     }
 
     #[test]

--- a/crates/phenotype-event-bus/src/lib.rs
+++ b/crates/phenotype-event-bus/src/lib.rs
@@ -96,16 +96,9 @@ pub trait EventBus: Send + Sync + 'static {
     async fn publish(&self, event: EventEnvelope<Self::Event>) -> Result<(), EventBusError>;
 
     /// Subscribe to events matching a pattern
-    async fn subscribe<F>(
-        &self,
-        subject: &str,
-        handler: F,
-    ) -> Result<Subscription, EventBusError>
+    async fn subscribe<F>(&self, subject: &str, handler: F) -> Result<Subscription, EventBusError>
     where
-        F: Fn(EventEnvelope<Self::Event>) -> Result<(), EventBusError>
-            + Send
-            + Sync
-            + 'static;
+        F: Fn(EventEnvelope<Self::Event>) -> Result<(), EventBusError> + Send + Sync + 'static;
 
     /// Request-response pattern
     async fn request<T: Serialize + DeserializeOwned + Send + Sync + Clone + Debug + 'static>(

--- a/crates/phenotype-event-bus/src/memory.rs
+++ b/crates/phenotype-event-bus/src/memory.rs
@@ -8,7 +8,8 @@ use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
 /// In-memory event bus for testing
-pub struct InMemoryEventBus<T: Serialize + DeserializeOwned + Send + Sync + Clone + Debug + 'static> {
+pub struct InMemoryEventBus<T: Serialize + DeserializeOwned + Send + Sync + Clone + Debug + 'static>
+{
     subscribers: Arc<DashMap<String, Vec<mpsc::UnboundedSender<EventEnvelope<T>>>>>,
     closed: Arc<RwLock<bool>>,
 }
@@ -64,11 +65,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + Debug + 'static> Ev
         Ok(())
     }
 
-    async fn subscribe<F>(
-        &self,
-        subject: &str,
-        handler: F,
-    ) -> Result<Subscription, EventBusError>
+    async fn subscribe<F>(&self, subject: &str, handler: F) -> Result<Subscription, EventBusError>
     where
         F: Fn(EventEnvelope<T>) -> Result<(), EventBusError> + Send + Sync + 'static,
     {
@@ -202,9 +199,12 @@ mod tests {
         bus.close().await.unwrap();
 
         let result = bus
-            .publish(EventEnvelope::new("test", TestEvent {
-                message: "test".to_string(),
-            }))
+            .publish(EventEnvelope::new(
+                "test",
+                TestEvent {
+                    message: "test".to_string(),
+                },
+            ))
             .await;
 
         assert!(matches!(result, Err(EventBusError::Connection(_))));

--- a/crates/phenotype-health/src/project.rs
+++ b/crates/phenotype-health/src/project.rs
@@ -211,7 +211,10 @@ impl ProjectHealth {
 
     /// Get summary of all findings
     pub fn all_findings(&self) -> Vec<&Finding> {
-        self.dimensions.values().flat_map(|d| d.findings.iter()).collect()
+        self.dimensions
+            .values()
+            .flat_map(|d| d.findings.iter())
+            .collect()
     }
 }
 

--- a/crates/phenotype-infrastructure/src/bulkhead.rs
+++ b/crates/phenotype-infrastructure/src/bulkhead.rs
@@ -66,7 +66,9 @@ impl Bulkhead {
         Ok(f().await)
     }
 
-    async fn acquire_execution_permit(&self) -> Result<SemaphorePermit<'_>, crate::InfrastructureError> {
+    async fn acquire_execution_permit(
+        &self,
+    ) -> Result<SemaphorePermit<'_>, crate::InfrastructureError> {
         // In a real implementation, we'd track concurrent vs queued separately
         // For now, we use a simple approach
         self.inner
@@ -129,16 +131,16 @@ mod tests {
 
         // First operation starts immediately
         let handle1 = tokio::spawn(async move {
-            bulkhead.execute(|| async {
-                tokio::time::sleep(Duration::from_millis(50)).await;
-                1
-            }).await
+            bulkhead
+                .execute(|| async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    1
+                })
+                .await
         });
 
         // Second operation either queues or starts after first finishes
-        let handle2 = tokio::spawn(async move {
-            bulkhead2.execute(|| async { 2 }).await
-        });
+        let handle2 = tokio::spawn(async move { bulkhead2.execute(|| async { 2 }).await });
 
         let result1 = handle1.await.unwrap();
         let result2 = handle2.await.unwrap();

--- a/crates/phenotype-infrastructure/src/circuit.rs
+++ b/crates/phenotype-infrastructure/src/circuit.rs
@@ -215,6 +215,9 @@ mod tests {
         assert!(result.is_ok());
 
         // Still half-open, need more successes
-        assert!(matches!(cb.state().await, CircuitState::HalfOpen | CircuitState::Closed));
+        assert!(matches!(
+            cb.state().await,
+            CircuitState::HalfOpen | CircuitState::Closed
+        ));
     }
 }

--- a/crates/phenotype-infrastructure/src/lib.rs
+++ b/crates/phenotype-infrastructure/src/lib.rs
@@ -8,10 +8,10 @@
 
 use thiserror::Error;
 
-pub mod pool;
-pub mod circuit;
-pub mod rate_limit;
 pub mod bulkhead;
+pub mod circuit;
+pub mod pool;
+pub mod rate_limit;
 
 /// Infrastructure errors
 #[derive(Error, Debug, Clone)]
@@ -30,10 +30,10 @@ pub enum InfrastructureError {
     Other(String),
 }
 
-pub use pool::{ConnectionPool, PooledConnection, PoolConfig};
-pub use circuit::{CircuitBreaker, CircuitConfig, CircuitState};
-pub use rate_limit::{RateLimiter, RateLimitConfig, TokenBucket};
 pub use bulkhead::{Bulkhead, BulkheadConfig};
+pub use circuit::{CircuitBreaker, CircuitConfig, CircuitState};
+pub use pool::{ConnectionPool, PoolConfig, PooledConnection};
+pub use rate_limit::{RateLimitConfig, RateLimiter, TokenBucket};
 
 #[cfg(test)]
 mod tests {

--- a/crates/phenotype-infrastructure/src/rate_limit.rs
+++ b/crates/phenotype-infrastructure/src/rate_limit.rs
@@ -75,8 +75,7 @@ impl TokenBucket {
     fn refill(&self, inner: &mut TokenBucketInner) {
         let now = Instant::now();
         let elapsed = now.duration_since(inner.last_refill);
-        let tokens_to_add =
-            elapsed.as_secs_f64() * self.config.refill_rate as f64;
+        let tokens_to_add = elapsed.as_secs_f64() * self.config.refill_rate as f64;
 
         inner.tokens = (inner.tokens + tokens_to_add).min(self.config.capacity as f64);
         inner.last_refill = now;

--- a/crates/phenotype-macros/tests/builder_integration_test.rs
+++ b/crates/phenotype-macros/tests/builder_integration_test.rs
@@ -26,7 +26,8 @@ fn test_builder_derive_signature() {
 #[test]
 fn test_all_derive_modules_present() {
     // Verify that all derive modules are present and accounted for
-    let modules = ["aggregate",
+    let modules = [
+        "aggregate",
         "command",
         "entity",
         "error",
@@ -34,7 +35,8 @@ fn test_all_derive_modules_present() {
         "value_object",
         "derive_builder",
         "derive_errors",
-        "derive_serde"];
+        "derive_serde",
+    ];
 
     assert_eq!(
         modules.len(),

--- a/crates/phenotype-macros/tests/macro_integration_tests.rs
+++ b/crates/phenotype-macros/tests/macro_integration_tests.rs
@@ -1,7 +1,6 @@
 //! Comprehensive integration tests for phenotype-macros
 //! Traces to: FR-MACRO-001, FR-MACRO-002, FR-MACRO-003
 
-
 // Test 1: Builder macro with single field
 // Traces to: FR-PHENO-MACRO-001
 #[test]

--- a/crates/phenotype-port-traits/src/inbound/mod.rs
+++ b/crates/phenotype-port-traits/src/inbound/mod.rs
@@ -1,11 +1,11 @@
 //! Inbound ports - use cases and handlers from the application's perspective.
 
-pub mod use_case;
 pub mod command;
-pub mod query;
 pub mod event;
+pub mod query;
+pub mod use_case;
 
-pub use use_case::UseCase;
 pub use command::CommandHandler;
-pub use query::QueryHandler;
 pub use event::EventHandler;
+pub use query::QueryHandler;
+pub use use_case::UseCase;

--- a/crates/phenotype-port-traits/src/outbound/cache.rs
+++ b/crates/phenotype-port-traits/src/outbound/cache.rs
@@ -38,10 +38,18 @@ pub trait CachePort: Send + Sync {
 #[async_trait]
 pub trait CacheJsonPort: Send + Sync {
     /// Get a value and deserialize it.
-    async fn get_json<T: serde::de::DeserializeOwned>(&self, key: &str) -> Result<Option<T>, CacheError>;
+    async fn get_json<T: serde::de::DeserializeOwned>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, CacheError>;
 
     /// Set a value after serializing it.
-    async fn set_json<T: serde::Serialize>(&self, key: &str, value: &T, ttl: Duration) -> Result<(), CacheError>;
+    async fn set_json<T: serde::Serialize>(
+        &self,
+        key: &str,
+        value: &T,
+        ttl: Duration,
+    ) -> Result<(), CacheError>;
 }
 
 /// Cache port for atomic counter operations.

--- a/crates/phenotype-port-traits/src/outbound/event.rs
+++ b/crates/phenotype-port-traits/src/outbound/event.rs
@@ -47,17 +47,24 @@ impl<E: DomainEvent> EventEnvelope<E> {
 #[async_trait]
 pub trait EventPublisher: Send + Sync {
     /// Publish a domain event.
-    async fn publish<E: DomainEvent>(&self, envelope: EventEnvelope<E>) -> Result<(), EventBusError>;
+    async fn publish<E: DomainEvent>(
+        &self,
+        envelope: EventEnvelope<E>,
+    ) -> Result<(), EventBusError>;
 
     /// Publish multiple events in a batch.
-    async fn publish_batch<E: DomainEvent>(&self, envelopes: Vec<EventEnvelope<E>>) -> Result<(), EventBusError>;
+    async fn publish_batch<E: DomainEvent>(
+        &self,
+        envelopes: Vec<EventEnvelope<E>>,
+    ) -> Result<(), EventBusError>;
 }
 
 /// Event subscriber port for consuming domain events.
 #[async_trait]
 pub trait EventSubscriber<E: DomainEvent>: Send + Sync {
     /// Subscribe to events of the given type.
-    async fn subscribe(&self, handler: impl EventHandler<E> + 'static) -> Result<(), EventBusError>;
+    async fn subscribe(&self, handler: impl EventHandler<E> + 'static)
+        -> Result<(), EventBusError>;
 
     /// Unsubscribe from events.
     async fn unsubscribe(&self) -> Result<(), EventBusError>;
@@ -111,9 +118,7 @@ mod tests {
 
     #[test]
     fn event_envelope_new() {
-        let event = TestEvent {
-            id: "agg-1".into(),
-        };
+        let event = TestEvent { id: "agg-1".into() };
         let envelope = EventEnvelope::new(event);
         assert_eq!(envelope.event_type, "test.event");
         assert_eq!(envelope.aggregate_id, "agg-1");
@@ -123,9 +128,7 @@ mod tests {
 
     #[test]
     fn event_envelope_with_correlation_id() {
-        let event = TestEvent {
-            id: "agg-1".into(),
-        };
+        let event = TestEvent { id: "agg-1".into() };
         let envelope = EventEnvelope::new(event).with_correlation_id("corr-123".into());
         assert_eq!(envelope.correlation_id.as_deref(), Some("corr-123"));
         assert!(envelope.causation_id.is_none());
@@ -133,9 +136,7 @@ mod tests {
 
     #[test]
     fn event_envelope_with_causation_id() {
-        let event = TestEvent {
-            id: "agg-1".into(),
-        };
+        let event = TestEvent { id: "agg-1".into() };
         let envelope = EventEnvelope::new(event).with_causation_id("cause-456".into());
         assert_eq!(envelope.causation_id.as_deref(), Some("cause-456"));
         assert!(envelope.correlation_id.is_none());
@@ -143,9 +144,7 @@ mod tests {
 
     #[test]
     fn event_envelope_chained_builder() {
-        let event = TestEvent {
-            id: "agg-1".into(),
-        };
+        let event = TestEvent { id: "agg-1".into() };
         let envelope = EventEnvelope::new(event)
             .with_correlation_id("corr-1".into())
             .with_causation_id("cause-1".into());
@@ -155,9 +154,7 @@ mod tests {
 
     #[test]
     fn event_envelope_debug() {
-        let event = TestEvent {
-            id: "agg-1".into(),
-        };
+        let event = TestEvent { id: "agg-1".into() };
         let envelope = EventEnvelope::new(event);
         let debug = format!("{:?}", envelope);
         assert!(debug.contains("test.event"));

--- a/crates/phenotype-port-traits/src/outbound/mod.rs
+++ b/crates/phenotype-port-traits/src/outbound/mod.rs
@@ -1,11 +1,11 @@
 //! Outbound ports - adapters and infrastructure from the application's perspective.
 
-pub mod repository;
 pub mod cache;
 pub mod event;
+pub mod repository;
 pub mod secret;
 
-pub use repository::{Repository, UnitOfWork};
-pub use cache::{CachePort, CacheJsonPort, CacheCounterPort, CacheLockPort};
+pub use cache::{CacheCounterPort, CacheJsonPort, CacheLockPort, CachePort};
 pub use event::{EventPublisher, EventSubscriber};
-pub use secret::{SecretPort, VersionedSecretPort, SecretRotator};
+pub use repository::{Repository, UnitOfWork};
+pub use secret::{SecretPort, SecretRotator, VersionedSecretPort};

--- a/crates/phenotype-project-registry/src/lib.rs
+++ b/crates/phenotype-project-registry/src/lib.rs
@@ -127,7 +127,10 @@ impl ProjectRegistry {
         let workflow_count = self.count_workflows(path).await;
 
         // Try to extract GitHub owner from git remote or use default
-        let owner = self.detect_owner(path).await.unwrap_or_else(|| "KooshaPari".to_string());
+        let owner = self
+            .detect_owner(path)
+            .await
+            .unwrap_or_else(|| "KooshaPari".to_string());
 
         Some(ProjectMetadata {
             name: name.to_string(),

--- a/crates/phenotype-security-aggregator/src/lib.rs
+++ b/crates/phenotype-security-aggregator/src/lib.rs
@@ -70,10 +70,7 @@ impl SecurityAggregator {
             .filter(|a| matches!(a.severity, Severity::Warning))
             .count();
 
-        let score = (100.0_f32
-            - critical as f32 * 25.0
-            - high as f32 * 10.0
-            - medium as f32 * 2.0)
+        let score = (100.0_f32 - critical as f32 * 25.0 - high as f32 * 10.0 - medium as f32 * 2.0)
             .max(0.0);
 
         let findings: Vec<Finding> = all_alerts
@@ -188,14 +185,8 @@ impl GitHubDependabotSource {
 
 #[async_trait]
 impl SecuritySource for GitHubDependabotSource {
-    async fn fetch_alerts(
-        &self,
-        owner: &str,
-        repo: &str,
-    ) -> anyhow::Result<Vec<SecurityAlert>> {
-        let url = format!(
-            "https://api.github.com/repos/{owner}/{repo}/dependabot/alerts"
-        );
+    async fn fetch_alerts(&self, owner: &str, repo: &str) -> anyhow::Result<Vec<SecurityAlert>> {
+        let url = format!("https://api.github.com/repos/{owner}/{repo}/dependabot/alerts");
 
         let _response = self
             .client

--- a/crates/phenotype-shared-config/src/dirs.rs
+++ b/crates/phenotype-shared-config/src/dirs.rs
@@ -128,8 +128,11 @@ mod tests {
 
     #[test]
     fn test_config_dir_search() {
-        let results: Vec<(ConfigDir, std::path::PathBuf)> = search_config_dirs::<&str>("nonexistent-app", ".config.toml", &[]);
+        let results: Vec<(ConfigDir, std::path::PathBuf)> =
+            search_config_dirs::<&str>("nonexistent-app", ".config.toml", &[]);
         // Should return empty or partial matches depending on environment
-        assert!(results.iter().all(|(d, p)| d != &ConfigDir::Env && p.exists()));
+        assert!(results
+            .iter()
+            .all(|(d, p)| d != &ConfigDir::Env && p.exists()));
     }
 }

--- a/crates/phenotype-shared-config/src/error.rs
+++ b/crates/phenotype-shared-config/src/error.rs
@@ -12,19 +12,34 @@ pub enum ConfigError {
     FileNotFound { path: String },
 
     #[error("failed to parse {format}: {reason}")]
-    Parse { format: &'static str, reason: String },
+    Parse {
+        format: &'static str,
+        reason: String,
+    },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
     #[error("JSON parse error: {reason}")]
-    JsonParse { #[allow(dead_code)] path: Option<String>, reason: String },
+    JsonParse {
+        #[allow(dead_code)]
+        path: Option<String>,
+        reason: String,
+    },
 
     #[error("TOML parse error: {reason}")]
-    TomlParse { #[allow(dead_code)] path: Option<String>, reason: String },
+    TomlParse {
+        #[allow(dead_code)]
+        path: Option<String>,
+        reason: String,
+    },
 
     #[error("YAML parse error: {reason}")]
-    YamlParse { #[allow(dead_code)] path: Option<String>, reason: String },
+    YamlParse {
+        #[allow(dead_code)]
+        path: Option<String>,
+        reason: String,
+    },
 }
 
 /// Result type alias for configuration operations.

--- a/crates/phenotype-shared-config/src/format.rs
+++ b/crates/phenotype-shared-config/src/format.rs
@@ -72,11 +72,13 @@ impl ConfigFormat {
     /// Parse content into a JSON Value.
     pub fn parse_to_json(self, content: &str) -> Result<JsonValue> {
         match self {
-            Self::Json => serde_json::from_str(content).map_err(|e| ConfigError::json_parse(e.to_string())),
+            Self::Json => {
+                serde_json::from_str(content).map_err(|e| ConfigError::json_parse(e.to_string()))
+            }
             #[cfg(feature = "toml")]
             Self::Toml => {
-                let value: toml::Value = toml::from_str(content)
-                    .map_err(|e| ConfigError::toml_parse(e.to_string()))?;
+                let value: toml::Value =
+                    toml::from_str(content).map_err(|e| ConfigError::toml_parse(e.to_string()))?;
                 serde_json::to_value(value).map_err(|e| ConfigError::custom("toml", e.to_string()))
             }
             #[cfg(not(feature = "toml"))]
@@ -100,7 +102,8 @@ impl ConfigFormat {
     /// Serialize a value to string in this format.
     pub fn serialize(self, value: &JsonValue) -> Result<String> {
         match self {
-            Self::Json => serde_json::to_string_pretty(value).map_err(|e| ConfigError::json_parse(e.to_string())),
+            Self::Json => serde_json::to_string_pretty(value)
+                .map_err(|e| ConfigError::json_parse(e.to_string())),
             #[cfg(feature = "toml")]
             Self::Toml => {
                 let value: toml::Value = serde_json::from_value(value.clone())
@@ -110,12 +113,13 @@ impl ConfigFormat {
             #[cfg(not(feature = "toml"))]
             Self::Toml => Err(ConfigError::custom("toml", "TOML feature not enabled")),
             #[cfg(feature = "yaml")]
-            Self::Yaml => serde_yaml::to_string(value).map_err(|e| ConfigError::yaml_parse(e.to_string())),
+            Self::Yaml => {
+                serde_yaml::to_string(value).map_err(|e| ConfigError::yaml_parse(e.to_string()))
+            }
             #[cfg(not(feature = "yaml"))]
             Self::Yaml => Err(ConfigError::custom("yaml", "YAML feature not enabled")),
-            Self::Auto => {
-                serde_json::to_string_pretty(value).map_err(|e| ConfigError::json_parse(e.to_string()))
-            }
+            Self::Auto => serde_json::to_string_pretty(value)
+                .map_err(|e| ConfigError::json_parse(e.to_string())),
         }
     }
 }
@@ -134,8 +138,14 @@ mod tests {
 
     #[test]
     fn test_from_content() {
-        assert_eq!(ConfigFormat::from_content(r#"{"key": "value"}"#), ConfigFormat::Json);
-        assert_eq!(ConfigFormat::from_content(r#"[section]"#), ConfigFormat::Toml);
+        assert_eq!(
+            ConfigFormat::from_content(r#"{"key": "value"}"#),
+            ConfigFormat::Json
+        );
+        assert_eq!(
+            ConfigFormat::from_content(r#"[section]"#),
+            ConfigFormat::Toml
+        );
         assert_eq!(ConfigFormat::from_content("key: value"), ConfigFormat::Yaml);
     }
 

--- a/crates/phenotype-shared-config/src/source.rs
+++ b/crates/phenotype-shared-config/src/source.rs
@@ -69,7 +69,11 @@ impl ConfigValue {
     }
 
     /// Create with custom priority.
-    pub fn with_priority(source: ConfigSource, priority: SourcePriority, value: serde_json::Value) -> Self {
+    pub fn with_priority(
+        source: ConfigSource,
+        priority: SourcePriority,
+        value: serde_json::Value,
+    ) -> Self {
         Self {
             source,
             priority,

--- a/crates/phenotype-string/src/compression.rs
+++ b/crates/phenotype-string/src/compression.rs
@@ -50,13 +50,11 @@ pub fn compress(data: &str, algorithm: CompressionAlgorithm) -> crate::Result<Ve
 pub fn decompress(data: &[u8], algorithm: CompressionAlgorithm) -> crate::Result<String> {
     match algorithm {
         CompressionAlgorithm::None => {
-            String::from_utf8(data.to_vec())
-                .map_err(|e| crate::Error::Invalid(e.to_string()))
+            String::from_utf8(data.to_vec()).map_err(|e| crate::Error::Invalid(e.to_string()))
         }
         _ => {
             // Stub implementation - just return as string
-            String::from_utf8(data.to_vec())
-                .map_err(|e| crate::Error::Invalid(e.to_string()))
+            String::from_utf8(data.to_vec()).map_err(|e| crate::Error::Invalid(e.to_string()))
         }
     }
 }

--- a/crates/phenotype-test-fixtures/src/property.rs
+++ b/crates/phenotype-test-fixtures/src/property.rs
@@ -100,7 +100,11 @@ where
 }
 
 /// Generate a random HashMap
-pub fn hash_map<K, V, Fk, Fv>(len: usize, key_gen: Fk, val_gen: Fv) -> std::collections::HashMap<K, V>
+pub fn hash_map<K, V, Fk, Fv>(
+    len: usize,
+    key_gen: Fk,
+    val_gen: Fv,
+) -> std::collections::HashMap<K, V>
 where
     K: std::cmp::Eq + std::hash::Hash,
     Fk: Fn() -> K,
@@ -141,7 +145,8 @@ impl PropertyTest {
     {
         for i in 0..self.iterations {
             test();
-            #[allow(clippy::manual_is_multiple_of)] // is_multiple_of stabilized in 1.87; MSRV is 1.86
+            #[allow(clippy::manual_is_multiple_of)]
+            // is_multiple_of stabilized in 1.87; MSRV is 1.86
             if i % 10 == 0 {
                 println!("  [{}] iteration {}/{}", self.name, i, self.iterations);
             }
@@ -196,11 +201,9 @@ mod tests {
     #[test]
     fn test_property_test() {
         let counter = std::cell::Cell::new(0);
-        PropertyTest::new("test")
-            .iterations(10)
-            .run(|| {
-                counter.set(counter.get() + 1);
-            });
+        PropertyTest::new("test").iterations(10).run(|| {
+            counter.set(counter.get() + 1);
+        });
         assert_eq!(counter.get(), 10);
     }
 }

--- a/crates/phenotype-test-infra/src/assertions.rs
+++ b/crates/phenotype-test-infra/src/assertions.rs
@@ -15,17 +15,17 @@ pub struct AssertionError {
 /// Assertion helpers trait
 pub trait Assertion {
     type Item;
-    
+
     /// Assert that the value is equal to expected
     fn assert_eq(&self, expected: &Self::Item, msg: &str) -> AssertionResult;
-    
+
     /// Assert that the value is not equal to expected
     fn assert_ne(&self, unexpected: &Self::Item, msg: &str) -> AssertionResult;
 }
 
 impl<T: PartialEq + std::fmt::Debug> Assertion for T {
     type Item = T;
-    
+
     fn assert_eq(&self, expected: &T, msg: &str) -> AssertionResult {
         if self != expected {
             return Err(AssertionError {
@@ -34,7 +34,7 @@ impl<T: PartialEq + std::fmt::Debug> Assertion for T {
         }
         Ok(())
     }
-    
+
     fn assert_ne(&self, unexpected: &T, msg: &str) -> AssertionResult {
         if self == unexpected {
             return Err(AssertionError {
@@ -86,7 +86,11 @@ pub fn assert_err<T, E>(res: &Result<T, E>, msg: &str) -> AssertionResult {
 }
 
 /// Assert that a vector contains an element
-pub fn assert_contains<T: PartialEq + std::fmt::Debug>(vec: &[T], item: &T, msg: &str) -> AssertionResult {
+pub fn assert_contains<T: PartialEq + std::fmt::Debug>(
+    vec: &[T],
+    item: &T,
+    msg: &str,
+) -> AssertionResult {
     if !vec.contains(item) {
         return Err(AssertionError {
             message: format!("{msg}: expected vector to contain {item:?}"),
@@ -99,9 +103,7 @@ pub fn assert_contains<T: PartialEq + std::fmt::Debug>(vec: &[T], item: &T, msg:
 pub fn assert_matches(haystack: &str, needle: &str, msg: &str) -> AssertionResult {
     if !haystack.contains(needle) {
         return Err(AssertionError {
-            message: format!(
-                "{msg}: expected '{haystack}' to contain '{needle}'"
-            ),
+            message: format!("{msg}: expected '{haystack}' to contain '{needle}'"),
         });
     }
     Ok(())

--- a/crates/phenotype-test-infra/src/lib.rs
+++ b/crates/phenotype-test-infra/src/lib.rs
@@ -6,11 +6,11 @@
 //! - Assertion helpers
 //! - Test utilities for async and sync code
 
+pub mod assertions;
 pub mod bdd;
 pub mod fixtures;
-pub mod assertions;
 
 // Re-export commonly used types
+pub use assertions::Assertion;
 pub use bdd::TestContext;
 pub use fixtures::Fixture;
-pub use assertions::Assertion;

--- a/crates/phenotype-xdd-lib/src/lib.rs
+++ b/crates/phenotype-xdd-lib/src/lib.rs
@@ -45,13 +45,13 @@
 //! assert!(valid_uuid("550e8400-e29b-41d4-a716-446655440000").is_ok());
 //! ```
 
-pub mod property;
 pub mod contract;
-pub mod mutation;
-pub mod spec;
 pub mod domain;
+pub mod mutation;
+pub mod property;
+pub mod spec;
 
 // Re-export commonly used items
+pub use contract::{Contract, ContractVerifier};
 pub use domain::{XddError, XddResult};
 pub use property::strategies;
-pub use contract::{Contract, ContractVerifier};

--- a/crates/phenotype-xdd-lib/src/mutation/mod.rs
+++ b/crates/phenotype-xdd-lib/src/mutation/mod.rs
@@ -145,7 +145,9 @@ impl MutationTracker {
 
     /// Get all tracked files.
     pub fn files(&self) -> impl Iterator<Item = (&str, usize)> {
-        self.files.iter().map(|(k, v)| (k.as_str(), v.lines_executed))
+        self.files
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.lines_executed))
     }
 }
 

--- a/crates/phenotype-xdd-lib/src/property/strategies.rs
+++ b/crates/phenotype-xdd-lib/src/property/strategies.rs
@@ -13,9 +13,9 @@
 //! - Collection strategies (non-empty, bounded size)
 //! - Composite strategies (valid entities)
 
-use proptest::strategy::Strategy;
-use proptest::prop_oneof;
 use crate::domain::{XddError, XddResult};
+use proptest::prop_oneof;
+use proptest::strategy::Strategy;
 
 /// Result type for strategy validation.
 pub type StrategyResult<T> = Result<T, XddError>;
@@ -27,11 +27,19 @@ pub fn valid_uuid(s: &str) -> XddResult<&str> {
     }
     let parts: Vec<&str> = s.split('-').collect();
     if parts.len() != 5 {
-        return Err(XddError::property("UUID must have 5 hyphen-separated parts"));
+        return Err(XddError::property(
+            "UUID must have 5 hyphen-separated parts",
+        ));
     }
-    if parts[0].len() != 8 || parts[1].len() != 4 || parts[2].len() != 4 ||
-       parts[3].len() != 4 || parts[4].len() != 12 {
-        return Err(XddError::property("UUID parts must be 8-4-4-4-12 characters"));
+    if parts[0].len() != 8
+        || parts[1].len() != 4
+        || parts[2].len() != 4
+        || parts[3].len() != 4
+        || parts[4].len() != 12
+    {
+        return Err(XddError::property(
+            "UUID parts must be 8-4-4-4-12 characters",
+        ));
     }
     Ok(s)
 }
@@ -46,10 +54,14 @@ pub fn valid_email(s: &str) -> XddResult<&str> {
         return Err(XddError::property("Email must have exactly one @"));
     }
     if parts[0].is_empty() || parts[1].is_empty() {
-        return Err(XddError::property("Email local and domain parts must be non-empty"));
+        return Err(XddError::property(
+            "Email local and domain parts must be non-empty",
+        ));
     }
     if !parts[1].contains('.') {
-        return Err(XddError::property("Email domain must contain at least one dot"));
+        return Err(XddError::property(
+            "Email domain must contain at least one dot",
+        ));
     }
     Ok(s)
 }
@@ -57,7 +69,9 @@ pub fn valid_email(s: &str) -> XddResult<&str> {
 /// Validate a URL format.
 pub fn valid_url(s: &str) -> XddResult<&str> {
     if !s.starts_with("http://") && !s.starts_with("https://") {
-        return Err(XddError::property("URL must start with http:// or https://"));
+        return Err(XddError::property(
+            "URL must start with http:// or https://",
+        ));
     }
     if s.len() < 10 {
         return Err(XddError::property("URL must be at least 10 characters"));
@@ -116,14 +130,12 @@ pub fn bounded_length(s: &str, min: usize, max: usize) -> XddResult<&str> {
 
 /// Generate a random valid UUID v4.
 pub fn uuid_strategy() -> impl Strategy<Value = String> {
-    "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
-        .prop_map(|s| s)
+    "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}".prop_map(|s| s)
 }
 
 /// Generate a random valid email.
 pub fn email_strategy() -> impl Strategy<Value = String> {
-    (".+@+.+", 3..100)
-        .prop_map(|(local, domain)| format!("{local}@{domain}"))
+    (".+@+.+", 3..100).prop_map(|(local, domain)| format!("{local}@{domain}"))
 }
 
 /// Generate a random bounded integer.

--- a/crates/phenotype-xdd-lib/src/spec/mod.rs
+++ b/crates/phenotype-xdd-lib/src/spec/mod.rs
@@ -30,8 +30,8 @@
 //! assert_eq!(spec.spec.name, "My Spec");
 //! ```
 
-use serde::{Deserialize, Serialize};
 use crate::domain::{XddError, XddResult};
+use serde::{Deserialize, Serialize};
 
 pub use parser::SpecParser;
 pub use validator::SpecValidator;
@@ -119,7 +119,6 @@ pub enum Priority {
     Low,
 }
 
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
@@ -131,16 +130,14 @@ pub enum Status {
     Deferred,
 }
 
-
 /// Parsed and validated specification.
 pub mod parser {
     use super::*;
 
     /// Parse specification from YAML string.
     pub fn parse_yaml(yaml: &str) -> XddResult<Spec> {
-        serde_yaml_ng::from_str(yaml).map_err(|e| {
-            XddError::spec(format!("Failed to parse YAML: {e}"))
-        })
+        serde_yaml_ng::from_str(yaml)
+            .map_err(|e| XddError::spec(format!("Failed to parse YAML: {e}")))
     }
 
     /// SpecParser with validation.
@@ -198,10 +195,12 @@ pub mod validator {
 
         fn validate_metadata(&mut self, meta: &SpecMetadata) {
             if meta.name.is_empty() {
-                self.errors.push(XddError::spec("Spec name cannot be empty"));
+                self.errors
+                    .push(XddError::spec("Spec name cannot be empty"));
             }
             if meta.version.is_empty() {
-                self.errors.push(XddError::spec("Spec version cannot be empty"));
+                self.errors
+                    .push(XddError::spec("Spec version cannot be empty"));
             }
         }
 
@@ -210,19 +209,23 @@ pub mod validator {
             for feature in features {
                 if !seen_ids.insert(&feature.id) {
                     self.errors.push(XddError::spec(format!(
-                        "Duplicate feature ID: {}", feature.id
+                        "Duplicate feature ID: {}",
+                        feature.id
                     )));
                 }
                 if feature.name.is_empty() {
-                    self.errors.push(XddError::spec("Feature name cannot be empty"));
+                    self.errors
+                        .push(XddError::spec("Feature name cannot be empty"));
                 }
                 // Either scenario or given/when/then should be present
-                if feature.scenario.is_none() &&
-                   feature.given.is_empty() &&
-                   feature.when.is_empty() &&
-                   feature.then.is_empty() {
+                if feature.scenario.is_none()
+                    && feature.given.is_empty()
+                    && feature.when.is_empty()
+                    && feature.then.is_empty()
+                {
                     self.errors.push(XddError::spec(format!(
-                        "Feature {} has no scenario or given/when/then", feature.id
+                        "Feature {} has no scenario or given/when/then",
+                        feature.id
                     )));
                 }
             }
@@ -233,11 +236,13 @@ pub mod validator {
             for req in requirements {
                 if !seen_ids.insert(&req.id) {
                     self.errors.push(XddError::spec(format!(
-                        "Duplicate requirement ID: {}", req.id
+                        "Duplicate requirement ID: {}",
+                        req.id
                     )));
                 }
                 if req.description.is_empty() {
-                    self.errors.push(XddError::spec("Requirement description cannot be empty"));
+                    self.errors
+                        .push(XddError::spec("Requirement description cannot be empty"));
                 }
             }
         }

--- a/crates/phenotype-xdd-lib/tests/contract_tests.rs
+++ b/crates/phenotype-xdd-lib/tests/contract_tests.rs
@@ -64,7 +64,6 @@ struct MemoryStorage {
     data: HashMap<String, String>,
 }
 
-
 impl StoragePort for MemoryStorage {
     fn get(&self, key: &str) -> Option<String> {
         self.data.get(key).cloned()

--- a/crates/phenotype-xdd-lib/tests/mutation_tests.rs
+++ b/crates/phenotype-xdd-lib/tests/mutation_tests.rs
@@ -4,9 +4,7 @@
 //!
 //! These tests verify the mutation tracking functionality.
 
-use phenotype_xdd_lib::mutation::{
-    MutationTracker, MutationKind, MutationStatus, CoverageReport,
-};
+use phenotype_xdd_lib::mutation::{CoverageReport, MutationKind, MutationStatus, MutationTracker};
 
 #[test]
 fn test_mutation_tracker_initialization() {
@@ -95,6 +93,12 @@ fn test_mutation_kind_variants() {
     assert_eq!(format!("{:?}", MutationKind::Arithmetic), "Arithmetic");
     assert_eq!(format!("{:?}", MutationKind::Comparison), "Comparison");
     assert_eq!(format!("{:?}", MutationKind::Boolean), "Boolean");
-    assert_eq!(format!("{:?}", MutationKind::ValueReplacement), "ValueReplacement");
-    assert_eq!(format!("{:?}", MutationKind::StatementRemoval), "StatementRemoval");
+    assert_eq!(
+        format!("{:?}", MutationKind::ValueReplacement),
+        "ValueReplacement"
+    );
+    assert_eq!(
+        format!("{:?}", MutationKind::StatementRemoval),
+        "StatementRemoval"
+    );
 }

--- a/crates/phenotype-xdd-lib/tests/property_tests.rs
+++ b/crates/phenotype-xdd-lib/tests/property_tests.rs
@@ -6,7 +6,7 @@
 //! using randomized inputs via proptest.
 
 use phenotype_xdd_lib::property::strategies::*;
-use proptest::{proptest, prop_assert};
+use proptest::{prop_assert, proptest};
 
 proptest! {
     #[test]

--- a/crates/settly/src/adapters/formats.rs
+++ b/crates/settly/src/adapters/formats.rs
@@ -1,6 +1,6 @@
 //! Format adapters for parsing configuration files.
 
-use crate::domain::{Config, ConfigValue, errors::ConfigError};
+use crate::domain::{errors::ConfigError, Config, ConfigValue};
 use std::collections::HashMap;
 
 /// TOML format parser.
@@ -8,11 +8,11 @@ pub struct TomlFormat;
 
 impl TomlFormat {
     pub fn parse(&self, content: &str) -> Result<Config, ConfigError> {
-        let value: toml::Value = toml::from_str(content)
-            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        let value: toml::Value =
+            toml::from_str(content).map_err(|e| ConfigError::ParseError(e.to_string()))?;
 
-        let values: serde_json::Value = serde_json::to_value(value)
-            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        let values: serde_json::Value =
+            serde_json::to_value(value).map_err(|e| ConfigError::ParseError(e.to_string()))?;
         let mut config = Config::new();
         for (key, value) in flatten_json(values) {
             config.set(key, parse_value(&value));
@@ -26,8 +26,8 @@ pub struct YamlFormat;
 
 impl YamlFormat {
     pub fn parse(&self, content: &str) -> Result<Config, ConfigError> {
-        let value: serde_yaml::Value = serde_yaml::from_str(content)
-            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        let value: serde_yaml::Value =
+            serde_yaml::from_str(content).map_err(|e| ConfigError::ParseError(e.to_string()))?;
 
         let values = value_to_json(value);
         let mut config = Config::new();
@@ -43,8 +43,8 @@ pub struct JsonFormat;
 
 impl JsonFormat {
     pub fn parse(&self, content: &str) -> Result<Config, ConfigError> {
-        let value: serde_json::Value = serde_json::from_str(content)
-            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        let value: serde_json::Value =
+            serde_json::from_str(content).map_err(|e| ConfigError::ParseError(e.to_string()))?;
 
         let mut config = Config::new();
         for (key, value) in flatten_json(value) {
@@ -76,9 +76,7 @@ fn value_to_json(value: serde_yaml::Value) -> serde_json::Value {
         serde_yaml::Value::Mapping(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .into_iter()
-                .filter_map(|(k, v)| {
-                    k.as_str().map(|k| (k.to_string(), value_to_json(v)))
-                })
+                .filter_map(|(k, v)| k.as_str().map(|k| (k.to_string(), value_to_json(v))))
                 .collect();
             serde_json::Value::Object(obj)
         }
@@ -90,19 +88,11 @@ fn parse_value(value: &serde_json::Value) -> ConfigValue {
     match value {
         serde_json::Value::Null => ConfigValue::Null,
         serde_json::Value::Bool(b) => ConfigValue::Bool(*b),
-        serde_json::Value::Number(n) => ConfigValue::Number(
-            n.as_f64().unwrap_or(0.0)
-        ),
+        serde_json::Value::Number(n) => ConfigValue::Number(n.as_f64().unwrap_or(0.0)),
         serde_json::Value::String(s) => ConfigValue::String(s.clone()),
-        serde_json::Value::Array(arr) => {
-            ConfigValue::Array(arr.iter().map(parse_value).collect())
-        }
+        serde_json::Value::Array(arr) => ConfigValue::Array(arr.iter().map(parse_value).collect()),
         serde_json::Value::Object(map) => {
-            ConfigValue::Object(
-                map.iter()
-                    .map(|(k, v)| (k.clone(), parse_value(v)))
-                    .collect()
-            )
+            ConfigValue::Object(map.iter().map(|(k, v)| (k.clone(), parse_value(v))).collect())
         }
     }
 }
@@ -119,11 +109,8 @@ fn flatten_json(value: serde_json::Value) -> HashMap<String, serde_json::Value> 
                     result.insert(prefix.to_string(), value.clone());
                 } else {
                     for (key, val) in map {
-                        let path = if prefix.is_empty() {
-                            key.clone()
-                        } else {
-                        format!("{prefix}.{key}")
-                        };
+                        let path =
+                            if prefix.is_empty() { key.clone() } else { format!("{prefix}.{key}") };
                         flatten_recursive(val, &path, result);
                     }
                 }

--- a/crates/settly/src/adapters/idempotency.rs
+++ b/crates/settly/src/adapters/idempotency.rs
@@ -26,10 +26,7 @@ pub struct InMemoryIdempotencyStore {
 impl InMemoryIdempotencyStore {
     /// Create with an explicit TTL.
     pub fn new(ttl: Duration) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(HashMap::new())),
-            ttl,
-        }
+        Self { inner: Arc::new(Mutex::new(HashMap::new())), ttl }
     }
 
     /// Default TTL: 24 hours.
@@ -56,11 +53,7 @@ impl IdempotencyStore for InMemoryIdempotencyStore {
         Ok(None)
     }
 
-    async fn set(
-        &self,
-        key: &IdempotencyKey,
-        result: SubmissionResult,
-    ) -> Result<(), ConfigError> {
+    async fn set(&self, key: &IdempotencyKey, result: SubmissionResult) -> Result<(), ConfigError> {
         let mut store = self.inner.lock().map_err(|e| {
             ConfigError::ParseError(format!("idempotency store lock poisoned: {e}"))
         })?;
@@ -76,9 +69,7 @@ pub struct InMemoryDlq {
 
 impl InMemoryDlq {
     pub fn new() -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(Vec::new())),
-        }
+        Self { inner: Arc::new(Mutex::new(Vec::new())) }
     }
 }
 

--- a/crates/settly/src/adapters/mod.rs
+++ b/crates/settly/src/adapters/mod.rs
@@ -1,9 +1,9 @@
 //! Adapters layer.
 
-pub mod sources;
 pub mod formats;
 pub mod idempotency;
+pub mod sources;
 
-pub use sources::{FileSource, EnvSource};
-pub use formats::{TomlFormat, YamlFormat, JsonFormat};
-pub use idempotency::{InMemoryIdempotencyStore, InMemoryDlq};
+pub use formats::{JsonFormat, TomlFormat, YamlFormat};
+pub use idempotency::{InMemoryDlq, InMemoryIdempotencyStore};
+pub use sources::{EnvSource, FileSource};

--- a/crates/settly/src/adapters/sources.rs
+++ b/crates/settly/src/adapters/sources.rs
@@ -1,11 +1,9 @@
 //! Configuration source adapters.
 
+use crate::domain::{errors::ConfigError, sources::Source, Config, ConfigValue};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
-use crate::domain::{
-    Config, ConfigValue, errors::ConfigError, sources::Source,
-};
 
 /// File-based configuration source.
 pub struct FileSource {
@@ -14,9 +12,7 @@ pub struct FileSource {
 
 impl FileSource {
     pub fn new(path: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-        }
+        Self { path: path.into() }
     }
 }
 
@@ -33,15 +29,16 @@ impl Source for FileSource {
     async fn load(&self) -> Result<Config, ConfigError> {
         let content = tokio::fs::read_to_string(&self.path).await?;
 
-        let extension = Path::new(&self.path)
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
+        let extension = Path::new(&self.path).extension().and_then(|e| e.to_str()).unwrap_or("");
 
         let values: serde_json::Value = match extension {
-            "toml" => toml::from_str(&content).map_err(|e| ConfigError::ParseError(e.to_string()))?,
-            "yaml" | "yml" => serde_yaml::from_str(&content).map_err(|e| ConfigError::ParseError(e.to_string()))?,
-            "json" => serde_json::from_str(&content).map_err(|e| ConfigError::ParseError(e.to_string()))?,
+            "toml" => {
+                toml::from_str(&content).map_err(|e| ConfigError::ParseError(e.to_string()))?
+            }
+            "yaml" | "yml" => serde_yaml::from_str(&content)
+                .map_err(|e| ConfigError::ParseError(e.to_string()))?,
+            "json" => serde_json::from_str(&content)
+                .map_err(|e| ConfigError::ParseError(e.to_string()))?,
             _ => return Err(ConfigError::ParseError(format!("Unknown extension: {extension}"))),
         };
 
@@ -151,11 +148,8 @@ fn flatten_json(value: serde_json::Value) -> HashMap<String, serde_json::Value> 
         match value {
             serde_json::Value::Object(map) => {
                 for (key, val) in map {
-                    let path = if prefix.is_empty() {
-                        key.clone()
-                    } else {
-                        format!("{prefix}.{key}")
-                    };
+                    let path =
+                        if prefix.is_empty() { key.clone() } else { format!("{prefix}.{key}") };
                     flatten_recursive(val, &path, result);
                 }
             }

--- a/crates/settly/src/application/builder.rs
+++ b/crates/settly/src/application/builder.rs
@@ -1,8 +1,8 @@
 //! Configuration builder.
 
 use crate::domain::{
-    Config, ConfigError, ConfigValue, LayerPriority, LayerStack, MergeStrategy,
-    sources::Source, validation::Validator,
+    sources::Source, validation::Validator, Config, ConfigError, ConfigValue, LayerPriority,
+    LayerStack, MergeStrategy,
 };
 use std::collections::HashMap;
 
@@ -15,18 +15,12 @@ pub struct ConfigBuilder {
 impl ConfigBuilder {
     /// Create a new builder.
     pub fn new() -> Self {
-        Self {
-            stack: LayerStack::new(),
-            validators: Vec::new(),
-        }
+        Self { stack: LayerStack::new(), validators: Vec::new() }
     }
 
     /// Create with a merge strategy.
     pub fn with_strategy(strategy: MergeStrategy) -> Self {
-        Self {
-            stack: LayerStack::with_strategy(strategy),
-            validators: Vec::new(),
-        }
+        Self { stack: LayerStack::with_strategy(strategy), validators: Vec::new() }
     }
 
     /// Add a source with priority.

--- a/crates/settly/src/application/submission.rs
+++ b/crates/settly/src/application/submission.rs
@@ -41,11 +41,7 @@ impl SubmissionService {
         dlq: Arc<dyn DeadLetterQueue>,
         max_retries: u32,
     ) -> Self {
-        Self {
-            store,
-            dlq,
-            max_retries,
-        }
+        Self { store, dlq, max_retries }
     }
 
     /// Submit work identified by `key`.
@@ -77,9 +73,8 @@ impl SubmissionService {
         for attempt in 0..=self.max_retries {
             match executor().await {
                 Ok(value) => {
-                    let payload = serde_json::to_value(&value).map_err(|e| {
-                        ConfigError::SerializationError(e.to_string())
-                    })?;
+                    let payload = serde_json::to_value(&value)
+                        .map_err(|e| ConfigError::SerializationError(e.to_string()))?;
                     let result = SubmissionResult::new(key.0.clone(), payload);
                     self.store.set(&key, result.clone()).await?;
                     return Ok(result);
@@ -98,11 +93,8 @@ impl SubmissionService {
         }
 
         // --- 3. Exhausted → DLQ ---
-        let entry = DeadLetterEntry::new(
-            key.0.clone(),
-            self.max_retries + 1,
-            last_error.to_string(),
-        );
+        let entry =
+            DeadLetterEntry::new(key.0.clone(), self.max_retries + 1, last_error.to_string());
         self.dlq.push(entry).await?;
         Err(last_error)
     }

--- a/crates/settly/src/application/submission_tests.rs
+++ b/crates/settly/src/application/submission_tests.rs
@@ -86,11 +86,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(
-                counter.load(Ordering::SeqCst),
-                1,
-                "executor must NOT run on duplicate key"
-            );
+            assert_eq!(counter.load(Ordering::SeqCst), 1, "executor must NOT run on duplicate key");
             assert!(result.from_cache, "second result must be marked from_cache");
             // Payload is from the first run, not the second
             assert_eq!(result.payload, serde_json::json!({"v": 42}));
@@ -138,9 +134,7 @@ mod tests {
         let key = IdempotencyKey::new("T4");
         let result = svc
             .submit(key, || async {
-                Err::<serde_json::Value, ConfigError>(ConfigError::ParseError(
-                    "boom".to_string(),
-                ))
+                Err::<serde_json::Value, ConfigError>(ConfigError::ParseError("boom".to_string()))
             })
             .await;
 
@@ -150,10 +144,7 @@ mod tests {
         assert_eq!(entries.len(), 1, "one entry must be in the DLQ");
         assert_eq!(entries[0].key, "T4");
         assert_eq!(entries[0].attempts, 2, "2 total attempts (1 + 1 retry)");
-        assert!(
-            entries[0].last_error.contains("boom"),
-            "DLQ entry must capture the error message"
-        );
+        assert!(entries[0].last_error.contains("boom"), "DLQ entry must capture the error message");
     }
 
     // -------------------------------------------------------------------------
@@ -198,10 +189,6 @@ mod tests {
             .unwrap();
         }
 
-        assert_eq!(
-            counter.load(Ordering::SeqCst),
-            2,
-            "executor must re-run after TTL expiry"
-        );
+        assert_eq!(counter.load(Ordering::SeqCst), 2, "executor must re-run after TTL expiry");
     }
 }

--- a/crates/settly/src/domain/config.rs
+++ b/crates/settly/src/domain/config.rs
@@ -66,17 +66,13 @@ impl ConfigValue {
         match value {
             serde_json::Value::Null => ConfigValue::Null,
             serde_json::Value::Bool(b) => ConfigValue::Bool(*b),
-            serde_json::Value::Number(n) => {
-                ConfigValue::Number(n.as_f64().unwrap_or(0.0))
-            }
+            serde_json::Value::Number(n) => ConfigValue::Number(n.as_f64().unwrap_or(0.0)),
             serde_json::Value::String(s) => ConfigValue::String(s.clone()),
             serde_json::Value::Array(items) => {
                 ConfigValue::Array(items.iter().map(Self::from_json).collect())
             }
             serde_json::Value::Object(map) => ConfigValue::Object(
-                map.iter()
-                    .map(|(k, v)| (k.clone(), Self::from_json(v)))
-                    .collect(),
+                map.iter().map(|(k, v)| (k.clone(), Self::from_json(v))).collect(),
             ),
         }
     }
@@ -188,18 +184,12 @@ pub struct Config {
 impl Config {
     /// Create a new empty configuration.
     pub fn new() -> Self {
-        Self {
-            values: HashMap::new(),
-            source: None,
-        }
+        Self { values: HashMap::new(), source: None }
     }
 
     /// Create from a values map.
     pub fn from_values(values: HashMap<String, ConfigValue>) -> Self {
-        Self {
-            values,
-            source: None,
-        }
+        Self { values, source: None }
     }
 
     /// Create with a source name.

--- a/crates/settly/src/domain/errors.rs
+++ b/crates/settly/src/domain/errors.rs
@@ -7,17 +7,10 @@ pub enum ConfigError {
     KeyNotFound(String),
 
     #[error("Type mismatch for {key}: expected {expected}, got {actual}")]
-    TypeMismatch {
-        key: String,
-        expected: String,
-        actual: String,
-    },
+    TypeMismatch { key: String, expected: String, actual: String },
 
     #[error("Validation failed: {validator}: {message}")]
-    ValidationFailed {
-        validator: String,
-        message: String,
-    },
+    ValidationFailed { validator: String, message: String },
 
     #[error("Parse error: {0}")]
     ParseError(String),

--- a/crates/settly/src/domain/idempotency.rs
+++ b/crates/settly/src/domain/idempotency.rs
@@ -2,9 +2,9 @@
 //!
 //! Provides a swappable key→result store and DLQ hook for submission deduplication.
 
-use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 use super::errors::ConfigError;
 
@@ -37,11 +37,7 @@ pub struct SubmissionResult {
 
 impl SubmissionResult {
     pub fn new(key: impl Into<String>, payload: serde_json::Value) -> Self {
-        Self {
-            key: key.into(),
-            payload,
-            from_cache: false,
-        }
+        Self { key: key.into(), payload, from_cache: false }
     }
 
     pub fn cached(mut self) -> Self {
@@ -60,11 +56,7 @@ pub struct DeadLetterEntry {
 
 impl DeadLetterEntry {
     pub fn new(key: impl Into<String>, attempts: u32, last_error: impl Into<String>) -> Self {
-        Self {
-            key: key.into(),
-            attempts,
-            last_error: last_error.into(),
-        }
+        Self { key: key.into(), attempts, last_error: last_error.into() }
     }
 }
 
@@ -78,11 +70,7 @@ pub struct CacheEntry {
 
 impl CacheEntry {
     pub fn new(result: SubmissionResult, ttl: Duration) -> Self {
-        Self {
-            result,
-            inserted_at: Instant::now(),
-            ttl,
-        }
+        Self { result, inserted_at: Instant::now(), ttl }
     }
 
     pub fn is_expired(&self) -> bool {
@@ -97,11 +85,7 @@ pub trait IdempotencyStore: Send + Sync {
     async fn get(&self, key: &IdempotencyKey) -> Result<Option<SubmissionResult>, ConfigError>;
 
     /// Persist a result under the given key with the configured TTL.
-    async fn set(
-        &self,
-        key: &IdempotencyKey,
-        result: SubmissionResult,
-    ) -> Result<(), ConfigError>;
+    async fn set(&self, key: &IdempotencyKey, result: SubmissionResult) -> Result<(), ConfigError>;
 }
 
 /// Port: dead-letter sink (in-memory Vec, log line, DB table, …).

--- a/crates/settly/src/domain/layers.rs
+++ b/crates/settly/src/domain/layers.rs
@@ -4,9 +4,7 @@ use super::config::Config;
 use serde::{Deserialize, Serialize};
 
 /// Layer priority levels.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 #[repr(u8)]
 pub enum LayerPriority {
     /// Built-in defaults (lowest priority).
@@ -38,11 +36,7 @@ pub struct Layer {
 impl Layer {
     /// Create a new layer.
     pub fn new(name: impl Into<String>, priority: LayerPriority, config: Config) -> Self {
-        Self {
-            name: name.into(),
-            priority,
-            config,
-        }
+        Self { name: name.into(), priority, config }
     }
 
     /// Create a default layer.
@@ -100,10 +94,7 @@ impl LayerStack {
 
     /// Create with a merge strategy.
     pub fn with_strategy(strategy: MergeStrategy) -> Self {
-        Self {
-            layers: Vec::new(),
-            strategy,
-        }
+        Self { layers: Vec::new(), strategy }
     }
 
     /// Add a layer.

--- a/crates/settly/src/domain/mod.rs
+++ b/crates/settly/src/domain/mod.rs
@@ -1,20 +1,19 @@
 //! Domain layer - pure configuration logic.
 
 pub mod config;
-pub mod layers;
-pub mod sources;
-pub mod validation;
-pub mod ports;
 pub mod errors;
 pub mod idempotency;
+pub mod layers;
+pub mod ports;
+pub mod sources;
+pub mod validation;
 
 // Re-exports
-pub use config::{Config, ConfigValue, ConfigPath};
+pub use config::{Config, ConfigPath, ConfigValue};
+pub use errors::ConfigError;
+pub use idempotency::{
+    DeadLetterEntry, DeadLetterQueue, IdempotencyKey, IdempotencyStore, SubmissionResult,
+};
 pub use layers::{Layer, LayerPriority, LayerStack, MergeStrategy};
 pub use sources::Source;
 pub use validation::Validator;
-pub use errors::ConfigError;
-pub use idempotency::{
-    IdempotencyKey, IdempotencyStore, SubmissionResult,
-    DeadLetterEntry, DeadLetterQueue,
-};

--- a/crates/settly/src/domain/sources.rs
+++ b/crates/settly/src/domain/sources.rs
@@ -1,8 +1,8 @@
 //! Configuration source definitions.
 
-use async_trait::async_trait;
 use super::config::Config;
 use super::errors::ConfigError;
+use async_trait::async_trait;
 
 /// Trait for configuration sources.
 #[async_trait]

--- a/crates/settly/src/domain/validation.rs
+++ b/crates/settly/src/domain/validation.rs
@@ -1,7 +1,7 @@
 //! Configuration validation.
 
-use super::errors::ConfigError;
 use super::config::{Config, ConfigValue};
+use super::errors::ConfigError;
 
 /// Validation rule.
 pub trait Validator: Send + Sync {
@@ -49,10 +49,7 @@ pub struct TypeValidator {
 
 impl TypeValidator {
     pub fn new(key: impl Into<String>, expected_type: &'static str) -> Self {
-        Self {
-            key: key.into(),
-            expected_type,
-        }
+        Self { key: key.into(), expected_type }
     }
 }
 
@@ -101,11 +98,7 @@ pub struct RangeValidator {
 
 impl RangeValidator {
     pub fn new(key: impl Into<String>) -> Self {
-        Self {
-            key: key.into(),
-            min: None,
-            max: None,
-        }
+        Self { key: key.into(), min: None, max: None }
     }
 
     pub fn with_min(mut self, min: f64) -> Self {
@@ -169,9 +162,7 @@ pub struct CompositeValidator {
 
 impl CompositeValidator {
     pub fn new() -> Self {
-        Self {
-            validators: Vec::new(),
-        }
+        Self { validators: Vec::new() }
     }
 
     pub fn push<V: Validator + 'static>(mut self, validator: V) -> Self {
@@ -218,9 +209,7 @@ mod tests {
 
     #[test]
     fn test_range_validator() {
-        let validator = RangeValidator::new("port")
-            .with_min(1.0)
-            .with_max(65535.0);
+        let validator = RangeValidator::new("port").with_min(1.0).with_max(65535.0);
 
         let mut config = Config::new();
         config.set("port", 8080);

--- a/crates/settly/src/lib.rs
+++ b/crates/settly/src/lib.rs
@@ -17,18 +17,20 @@
 //! let config = ConfigBuilder::new().build().unwrap();
 //! ```
 
-pub mod domain;
-pub mod application;
 pub mod adapters;
+pub mod application;
+pub mod domain;
 pub mod infrastructure;
 
 // Re-exports
-pub use domain::{Config, ConfigValue, Layer, LayerPriority};
-pub use domain::errors::ConfigError;
-pub use domain::{IdempotencyKey, IdempotencyStore, SubmissionResult, DeadLetterEntry, DeadLetterQueue};
+pub use adapters::idempotency::{InMemoryDlq, InMemoryIdempotencyStore};
 pub use application::builder::ConfigBuilder;
 pub use application::submission::SubmissionService;
-pub use adapters::idempotency::{InMemoryIdempotencyStore, InMemoryDlq};
+pub use domain::errors::ConfigError;
+pub use domain::{Config, ConfigValue, Layer, LayerPriority};
+pub use domain::{
+    DeadLetterEntry, DeadLetterQueue, IdempotencyKey, IdempotencyStore, SubmissionResult,
+};
 pub use infrastructure::error::ConfigKitError;
 
 /// Framework version

--- a/crates/stashly/src/adapters/memory.rs
+++ b/crates/stashly/src/adapters/memory.rs
@@ -1,14 +1,14 @@
 //! In-memory cache adapter.
 
-use std::sync::{Arc, RwLock};
-use std::num::NonZeroUsize;
-use async_trait::async_trait;
-use lru::LruCache;
 use crate::domain::{
-    Cache, CacheKey, CacheValue, Entry,
     policy::{EvictionPolicy, LruPolicy},
+    Cache, CacheKey, CacheValue, Entry,
 };
+use async_trait::async_trait;
 use chrono::Duration;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, RwLock};
 
 /// In-memory cache implementation.
 pub struct InMemoryCache {
@@ -19,8 +19,8 @@ pub struct InMemoryCache {
 
 impl InMemoryCache {
     pub fn new(max_capacity: usize) -> Self {
-        let capacity = NonZeroUsize::new(max_capacity)
-            .expect("max_capacity must be greater than zero");
+        let capacity =
+            NonZeroUsize::new(max_capacity).expect("max_capacity must be greater than zero");
         Self {
             cache: Arc::new(RwLock::new(LruCache::new(capacity))),
             policy: Arc::new(RwLock::new(LruPolicy::new())),

--- a/crates/stashly/src/adapters/tiered/mod.rs
+++ b/crates/stashly/src/adapters/tiered/mod.rs
@@ -46,9 +46,7 @@ impl TieredCache {
     /// Create a cache with custom configuration.
     pub fn with_config(l1_max_size: usize, _l2_max_size: usize, default_ttl: Ttl) -> Self {
         Self {
-            l1: Mutex::new(LruCache::new(
-                std::num::NonZeroUsize::new(l1_max_size).unwrap(),
-            )),
+            l1: Mutex::new(LruCache::new(std::num::NonZeroUsize::new(l1_max_size).unwrap())),
             l2: DashMap::new(),
             stats: Mutex::new(CacheStats::new()),
             events: Mutex::new(Vec::new()),
@@ -143,8 +141,7 @@ impl CachePort for TieredCache {
     }
 
     fn get_entry(&self, key: &CacheKey) -> Option<CacheEntry> {
-        self.get_internal(key)
-            .map(|(value, _tier)| CacheEntry::new(key.clone(), value))
+        self.get_internal(key).map(|(value, _tier)| CacheEntry::new(key.clone(), value))
     }
 }
 

--- a/crates/stashly/src/application/services.rs
+++ b/crates/stashly/src/application/services.rs
@@ -1,8 +1,8 @@
 //! Cache application service.
 
-use std::sync::Arc;
-use crate::domain::{Cache, CacheKey, CacheValue};
 use crate::domain::errors::CacheError;
+use crate::domain::{Cache, CacheKey, CacheValue};
+use std::sync::Arc;
 
 /// Cache service with typed operations.
 pub struct CacheService {
@@ -36,30 +36,22 @@ impl CacheService {
         value: &T,
     ) -> Result<(), CacheError> {
         let cache_value = CacheValue::serialize(value)?;
-        self.cache.set(key, cache_value)
-            .await
-            .map_err(CacheError::BackendError)
+        self.cache.set(key, cache_value).await.map_err(CacheError::BackendError)
     }
 
     /// Remove a key from the cache.
     pub async fn remove(&self, key: &CacheKey) -> Result<(), CacheError> {
-        self.cache.remove(key)
-            .await
-            .map_err(CacheError::BackendError)
+        self.cache.remove(key).await.map_err(CacheError::BackendError)
     }
 
     /// Check if a key exists.
     pub async fn contains(&self, key: &CacheKey) -> Result<bool, CacheError> {
-        self.cache.contains(key)
-            .await
-            .map_err(CacheError::BackendError)
+        self.cache.contains(key).await.map_err(CacheError::BackendError)
     }
 
     /// Get cache size.
     pub async fn len(&self) -> Result<usize, CacheError> {
-        self.cache.len()
-            .await
-            .map_err(CacheError::BackendError)
+        self.cache.len().await.map_err(CacheError::BackendError)
     }
 
     /// Check whether the cache is empty.

--- a/crates/stashly/src/domain/cache.rs
+++ b/crates/stashly/src/domain/cache.rs
@@ -1,10 +1,10 @@
 //! Cache entities.
 
-use serde::{Deserialize, Serialize};
-use chrono::{DateTime, Utc};
-use std::hash::{Hash, Hasher};
-use std::borrow::Cow;
 use super::errors::CacheError;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::hash::{Hash, Hasher};
 
 /// Cache key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,11 +65,7 @@ pub struct CacheValue {
 
 impl CacheValue {
     pub fn new(data: Vec<u8>) -> Self {
-        Self {
-            data,
-            content_type: None,
-            created_at: Utc::now(),
-        }
+        Self { data, content_type: None, created_at: Utc::now() }
     }
 
     pub fn with_content_type(mut self, ct: impl Into<String>) -> Self {
@@ -83,8 +79,8 @@ impl CacheValue {
     }
 
     pub fn serialize<T: serde::Serialize>(value: &T) -> Result<Self, CacheError> {
-        let data = serde_json::to_vec(value)
-            .map_err(|e| CacheError::SerializationError(e.to_string()))?;
+        let data =
+            serde_json::to_vec(value).map_err(|e| CacheError::SerializationError(e.to_string()))?;
         Ok(Self::new(data))
     }
 }
@@ -103,14 +99,7 @@ pub struct Entry {
 impl Entry {
     pub fn new(key: CacheKey, value: CacheValue) -> Self {
         let now = Utc::now();
-        Self {
-            key,
-            value,
-            ttl: None,
-            expires_at: None,
-            access_count: 0,
-            last_accessed: now,
-        }
+        Self { key, value, ttl: None, expires_at: None, access_count: 0, last_accessed: now }
     }
 
     pub fn with_ttl(mut self, ttl: chrono::Duration) -> Self {
@@ -165,10 +154,8 @@ mod tests {
 
     #[test]
     fn test_entry_expiry() {
-        let mut entry = Entry::new(
-            CacheKey::from("test"),
-            CacheValue::new(vec![]),
-        ).with_ttl(chrono::Duration::hours(1));
+        let mut entry = Entry::new(CacheKey::from("test"), CacheValue::new(vec![]))
+            .with_ttl(chrono::Duration::hours(1));
 
         assert!(!entry.is_expired());
         assert!(entry.remaining_ttl().is_some());

--- a/crates/stashly/src/domain/entities/mod.rs
+++ b/crates/stashly/src/domain/entities/mod.rs
@@ -113,13 +113,7 @@ pub struct SingleflightRequest<T> {
 impl<T> SingleflightRequest<T> {
     /// Create a new singleflight request.
     pub fn new(key: impl Into<String>) -> Self {
-        Self {
-            key: key.into(),
-            result: None,
-            waiters: 1,
-            created_at: Instant::now(),
-            error: None,
-        }
+        Self { key: key.into(), result: None, waiters: 1, created_at: Instant::now(), error: None }
     }
 
     /// Add a waiter.

--- a/crates/stashly/src/domain/events/mod.rs
+++ b/crates/stashly/src/domain/events/mod.rs
@@ -15,20 +15,11 @@ use std::time::SystemTime;
 #[derive(Debug, Clone)]
 pub enum CacheEvent {
     /// Cache hit event
-    CacheHit {
-        key: String,
-        tier: CacheTier,
-        timestamp: SystemTime,
-    },
+    CacheHit { key: String, tier: CacheTier, timestamp: SystemTime },
     /// Cache miss event
     CacheMiss { key: String, timestamp: SystemTime },
     /// Cache entry created
-    CacheEntryCreated {
-        key: String,
-        tier: CacheTier,
-        ttl_secs: u64,
-        timestamp: SystemTime,
-    },
+    CacheEntryCreated { key: String, tier: CacheTier, ttl_secs: u64, timestamp: SystemTime },
     /// Cache entry evicted
     CacheEntryEvicted {
         key: String,
@@ -37,23 +28,11 @@ pub enum CacheEvent {
         timestamp: SystemTime,
     },
     /// Cache entry expired
-    CacheEntryExpired {
-        key: String,
-        tier: CacheTier,
-        timestamp: SystemTime,
-    },
+    CacheEntryExpired { key: String, tier: CacheTier, timestamp: SystemTime },
     /// Cache cleared
-    CacheCleared {
-        tier: Option<CacheTier>,
-        entries_removed: usize,
-        timestamp: SystemTime,
-    },
+    CacheCleared { tier: Option<CacheTier>, entries_removed: usize, timestamp: SystemTime },
     /// Singleflight request started
-    SingleflightStarted {
-        key: String,
-        requester_pid: u32,
-        timestamp: SystemTime,
-    },
+    SingleflightStarted { key: String, requester_pid: u32, timestamp: SystemTime },
     /// Singleflight request completed
     SingleflightCompleted {
         key: String,
@@ -62,12 +41,7 @@ pub enum CacheEvent {
         timestamp: SystemTime,
     },
     /// Singleflight request failed
-    SingleflightFailed {
-        key: String,
-        error: String,
-        waiters: u32,
-        timestamp: SystemTime,
-    },
+    SingleflightFailed { key: String, error: String, waiters: u32, timestamp: SystemTime },
 }
 
 impl CacheEvent {

--- a/crates/stashly/src/domain/mod.rs
+++ b/crates/stashly/src/domain/mod.rs
@@ -1,15 +1,15 @@
 //! Domain layer.
 
 pub mod cache;
+pub mod entities;
+pub mod errors;
+pub mod events;
 pub mod policy;
 pub mod ports;
-pub mod errors;
-pub mod entities;
-pub mod events;
 pub mod value_objects;
 
 // Re-exports
 pub use cache::{CacheKey, CacheValue, Entry};
-pub use policy::{EvictionPolicy, LruPolicy, LfuPolicy, TtlPolicy};
 pub use errors::CacheError;
+pub use policy::{EvictionPolicy, LfuPolicy, LruPolicy, TtlPolicy};
 pub use ports::Cache;

--- a/crates/stashly/src/domain/policy.rs
+++ b/crates/stashly/src/domain/policy.rs
@@ -23,10 +23,7 @@ pub struct LruPolicy {
 
 impl LruPolicy {
     pub fn new() -> Self {
-        Self {
-            order: Vec::new(),
-            access_order: std::collections::HashMap::new(),
-        }
+        Self { order: Vec::new(), access_order: std::collections::HashMap::new() }
     }
 }
 
@@ -65,9 +62,7 @@ pub struct LfuPolicy {
 
 impl LfuPolicy {
     pub fn new() -> Self {
-        Self {
-            access_counts: std::collections::HashMap::new(),
-        }
+        Self { access_counts: std::collections::HashMap::new() }
     }
 }
 
@@ -83,10 +78,7 @@ impl EvictionPolicy for LfuPolicy {
     }
 
     fn select_eviction(&self) -> Option<String> {
-        self.access_counts
-            .iter()
-            .min_by_key(|(_, count)| *count)
-            .map(|(k, _)| k.clone())
+        self.access_counts.iter().min_by_key(|(_, count)| *count).map(|(k, _)| k.clone())
     }
 
     fn remove(&mut self, key: &str) {
@@ -105,9 +97,7 @@ pub struct TtlPolicy {
 
 impl TtlPolicy {
     pub fn new() -> Self {
-        Self {
-            expiration_order: Vec::new(),
-        }
+        Self { expiration_order: Vec::new() }
     }
 }
 
@@ -124,10 +114,7 @@ impl EvictionPolicy for TtlPolicy {
 
     fn select_eviction(&self) -> Option<String> {
         let now = chrono::Utc::now();
-        self.expiration_order
-            .iter()
-            .find(|(_, expires)| *expires < now)
-            .map(|(k, _)| k.clone())
+        self.expiration_order.iter().find(|(_, expires)| *expires < now).map(|(k, _)| k.clone())
     }
 
     fn remove(&mut self, key: &str) {
@@ -161,9 +148,15 @@ mod tests {
     fn test_lfu_policy() {
         let mut policy = LfuPolicy::new();
 
-        for _ in 0..3 { policy.record_access("a"); }
-        for _ in 0..1 { policy.record_access("b"); }
-        for _ in 0..2 { policy.record_access("c"); }
+        for _ in 0..3 {
+            policy.record_access("a");
+        }
+        for _ in 0..1 {
+            policy.record_access("b");
+        }
+        for _ in 0..2 {
+            policy.record_access("c");
+        }
 
         assert_eq!(policy.select_eviction(), Some("b".to_string()));
     }

--- a/crates/stashly/src/domain/ports.rs
+++ b/crates/stashly/src/domain/ports.rs
@@ -1,7 +1,7 @@
 //! Port definitions.
 
-use async_trait::async_trait;
 use super::{CacheKey, CacheValue};
+use async_trait::async_trait;
 
 /// Trait for cache implementations.
 #[async_trait]

--- a/crates/stashly/src/domain/value_objects/mod.rs
+++ b/crates/stashly/src/domain/value_objects/mod.rs
@@ -298,12 +298,7 @@ pub struct CacheConfig {
 
 impl CacheConfig {
     pub fn new(l1_max_size: usize, l2_max_size: usize, default_ttl: Ttl) -> Self {
-        Self {
-            l1_max_size,
-            l2_max_size,
-            default_ttl,
-            cleanup_interval: Duration::from_secs(60),
-        }
+        Self { l1_max_size, l2_max_size, default_ttl, cleanup_interval: Duration::from_secs(60) }
     }
 
     pub fn with_cleanup_interval(mut self, interval: Duration) -> Self {

--- a/crates/stashly/src/lib.rs
+++ b/crates/stashly/src/lib.rs
@@ -23,24 +23,24 @@
 //! - **Events**: Domain events for cache operations
 //! - **TTL & Eviction**: Configurable expiration policies
 
-pub mod domain;
-pub mod application;
 pub mod adapters;
-pub mod ports;
+pub mod application;
+pub mod domain;
 pub mod infrastructure;
+pub mod ports;
 
 // Re-exports (original Stashly)
-pub use domain::{Cache, CacheKey, CacheValue, Entry};
-pub use domain::errors::CacheError;
 pub use adapters::memory::InMemoryCache;
+pub use domain::errors::CacheError;
+pub use domain::{Cache, CacheKey, CacheValue, Entry};
 pub use infrastructure::error::CacheKitError;
 
 // Re-exports (from thegent-cache)
-pub use ports::driven::{CachePort, CacheWritePort, SingleflightPort, StatsPort, EvictionPort};
-pub use domain::entities::{CacheEntry, SingleflightRequest};
-pub use domain::value_objects::{CacheStats, CacheTier, Ttl};
-pub use domain::events::CacheEvent;
 pub use adapters::tiered::TieredCache;
+pub use domain::entities::{CacheEntry, SingleflightRequest};
+pub use domain::events::CacheEvent;
+pub use domain::value_objects::{CacheStats, CacheTier, Ttl};
+pub use ports::driven::{CachePort, CacheWritePort, EvictionPort, SingleflightPort, StatsPort};
 
 /// Two-tier cache re-export for convenience
 pub mod cache {

--- a/forgecode-fork/src/agents/mod.rs
+++ b/forgecode-fork/src/agents/mod.rs
@@ -29,11 +29,7 @@ impl AgentConfig {
         }
     }
 
-    pub fn with_metadata(
-        mut self,
-        key: impl Into<String>,
-        value: serde_json::Value,
-    ) -> Self {
+    pub fn with_metadata(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
         self.metadata.insert(key.into(), value);
         self
     }
@@ -53,11 +49,7 @@ impl Agent {
         &self.config
     }
 
-    pub async fn execute(
-        &self,
-        _input: &str,
-        _registry: &ProviderRegistry,
-    ) -> Result<String> {
+    pub async fn execute(&self, _input: &str, _registry: &ProviderRegistry) -> Result<String> {
         Ok(format!(
             "executed agent {} v{}",
             self.config.name, self.config.version
@@ -103,7 +95,12 @@ impl AgentExecutor {
             .unwrap_or_default()
     }
 
-    pub async fn execute(&self, agent_id: &str, input: &str, registry: &ProviderRegistry) -> Result<String> {
+    pub async fn execute(
+        &self,
+        agent_id: &str,
+        input: &str,
+        registry: &ProviderRegistry,
+    ) -> Result<String> {
         let agent = self
             .get(agent_id)
             .ok_or_else(|| ForgecodeError::AgentNotFound(agent_id.into()))?;

--- a/libs/nexus/src/discovery.rs
+++ b/libs/nexus/src/discovery.rs
@@ -1,7 +1,7 @@
 //! Service discovery module
 
+use crate::{NexusError, Registry, Service};
 use std::hash::BuildHasher;
-use crate::{Registry, Service, NexusError};
 
 /// Discovery strategies for load balancing
 #[derive(Debug, Clone)]
@@ -52,7 +52,10 @@ mod tests {
     #[tokio::test]
     async fn test_discovery_round_robin() {
         let registry = Registry::new();
-        registry.register(Service::new("api", crate::Endpoint::new("localhost:8080"))).await.unwrap();
+        registry
+            .register(Service::new("api", crate::Endpoint::new("localhost:8080")))
+            .await
+            .unwrap();
         let discovery = Discovery::new(registry, Strategy::RoundRobin);
         let service = discovery.next("api").await.unwrap();
         assert!(service.is_some());

--- a/libs/nexus/src/health.rs
+++ b/libs/nexus/src/health.rs
@@ -160,7 +160,10 @@ impl HealthMonitor {
     /// Get health status for a service
     pub async fn get_health(&self, service_name: &str) -> Option<HealthStatus> {
         let services = self.services.read().await;
-        services.iter().find(|s| s.service_name == service_name).map(|s| s.status.clone())
+        services
+            .iter()
+            .find(|s| s.service_name == service_name)
+            .map(|s| s.status.clone())
     }
 
     /// Get all service health statuses
@@ -204,7 +207,10 @@ mod tests {
         monitor.register_service("test-svc".to_string()).await;
         monitor.record_success("test-svc").await;
         monitor.record_success("test-svc").await;
-        assert_eq!(monitor.get_health("test-svc").await, Some(HealthStatus::Healthy));
+        assert_eq!(
+            monitor.get_health("test-svc").await,
+            Some(HealthStatus::Healthy)
+        );
     }
 
     #[tokio::test]
@@ -214,7 +220,10 @@ mod tests {
         monitor.record_failure("test-svc").await;
         monitor.record_failure("test-svc").await;
         monitor.record_failure("test-svc").await;
-        assert_eq!(monitor.get_health("test-svc").await, Some(HealthStatus::Unhealthy));
+        assert_eq!(
+            monitor.get_health("test-svc").await,
+            Some(HealthStatus::Unhealthy)
+        );
     }
 
     #[tokio::test]

--- a/libs/nexus/src/lib.rs
+++ b/libs/nexus/src/lib.rs
@@ -15,14 +15,14 @@
 //! # }
 //! ```
 
-pub mod registry;
-pub mod service;
 pub mod discovery;
 pub mod error;
 pub mod health;
+pub mod registry;
+pub mod service;
 
-pub use registry::Registry;
-pub use service::{Service, Endpoint};
 pub use discovery::Discovery;
 pub use error::NexusError;
-pub use health::{HealthMonitor, HealthStatus, HealthCheckConfig, ServiceHealth};
+pub use health::{HealthCheckConfig, HealthMonitor, HealthStatus, ServiceHealth};
+pub use registry::Registry;
+pub use service::{Endpoint, Service};

--- a/libs/nexus/src/registry.rs
+++ b/libs/nexus/src/registry.rs
@@ -1,9 +1,9 @@
 //! Service registry module
 
+use crate::{NexusError, Service};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use crate::{Service, NexusError};
 
 /// Service registry for managing service registrations
 ///
@@ -36,7 +36,9 @@ impl Registry {
     /// Register a service
     pub async fn register(&self, service: Service) -> Result<(), NexusError> {
         let mut services = self.services.write().await;
-        let entries = services.entry(service.name.clone()).or_insert_with(Vec::new);
+        let entries = services
+            .entry(service.name.clone())
+            .or_insert_with(Vec::new);
         entries.push(service);
         Ok(())
     }
@@ -79,8 +81,17 @@ mod tests {
     #[tokio::test]
     async fn test_registry_deregister() {
         let registry = Registry::new();
-        registry.register(Service::new("test-svc", crate::Endpoint::new("localhost:8080"))).await.unwrap();
-        registry.deregister("test-svc", "localhost:8080").await.unwrap();
+        registry
+            .register(Service::new(
+                "test-svc",
+                crate::Endpoint::new("localhost:8080"),
+            ))
+            .await
+            .unwrap();
+        registry
+            .deregister("test-svc", "localhost:8080")
+            .await
+            .unwrap();
         let discovered = registry.discover("test-svc").await.unwrap();
         assert!(discovered.is_empty());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,14 @@
 //! symmetric encryption (AES-GCM), key derivation (PBKDF2),
 //! HMAC signatures, and secure random generation.
 
-pub mod hash;
 pub mod encryption;
+pub mod hash;
 pub mod keys;
 pub mod signatures;
 
-pub use hash::{blake3_hash, content_id, sha256_hash, HashAlgorithm};
 pub use encryption::{
-    decrypt_aes_gcm, encrypt_aes_gcm, decrypt_aes_gcm_hex, encrypt_aes_gcm_hex, CryptoError,
+    decrypt_aes_gcm, decrypt_aes_gcm_hex, encrypt_aes_gcm, encrypt_aes_gcm_hex, CryptoError,
 };
+pub use hash::{blake3_hash, content_id, sha256_hash, HashAlgorithm};
 pub use keys::{generate_salt, generate_salt_hex, Pbkdf2Kdf};
 pub use signatures::{compute_hmac, compute_hmac_hex, verify_hmac, verify_hmac_hex};


### PR DESCRIPTION
## **User description**
L1.4 governance keystone per L1 audit 2026-06-12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only governance verification plus formatting; the ParseIntError conversion is a narrow, backward-compatible error-mapping addition.
> 
> **Overview**
> Adds **Governance Baseline Audit** (`.github/workflows/governance.yml`), which runs on a weekly schedule, pushes to `main`, and manual dispatch. It fails CI if any L1.4 keystone file is missing: `scorecard.yml`, `governance.yml`, `dependabot.yml`, `SECURITY.md`, and `cliff.toml`.
> 
> The rest of the diff is **mechanical formatting** across Metron, Traceon, settly, stashly, phenotype crates, nexus, forgecode-fork, and root crypto—import/module ordering, line breaks, and clippy-style layout with **no intended behavior changes**.
> 
> The only functional tweak in that sweep is in **`phenotype-error-core`**: `ConfigError` now implements **`From<std::num::ParseIntError>`** (mapped to a parse error with format `"int"`), plus a unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23de1d58184a5c94e05fb7e4ef1fd0d14166e14f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a governance audit and accept integer parse errors in config handling**

### What Changed
- Added a weekly and manual governance check that fails if required baseline files are missing
- Config errors now cover failed integer parsing, with a direct parse error message for that case
- The rest of the changes are formatting and module-order cleanup with no expected behavior change

### Impact
`✅ Fewer missing governance files`
`✅ Clearer config parse errors`
`✅ Earlier detection of repo compliance gaps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
