### PR TITLE
docs(obs): Wave A MIGRATED.md stubs for PhenoObservability

### DIFF
--- a/Metron/MIGRATED.md
+++ b/Metron/MIGRATED.md
@@ -1,0 +1,23 @@
+# Migration: Metron → PhenoObservability
+
+**Date:** 2026-06-17  
+**Disposition row:** HexaKit DISPOSITION #48 — `Metron/`  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Absorption map:** [wave-a-absorption.md](https://github.com/KooshaPari/PhenoObservability/blob/main/docs/disposition/wave-a-absorption.md)
+
+## What changed
+
+- This path received a **redirect stub** per [crate relocation runbook step 6](../../docs/operations/crate-relocation-runbook.md).
+- Canonical metrics ownership moves to **`PhenoObservability`** (`rust/phenotype-metrics`; HexaKit `metrickit` absorbed there).
+- **Source is retained** in HexaKit for this wave — removal follows downstream repoint (runbook steps 4–5, 7).
+
+## For consumers
+
+1. Depend on metrics from **PhenoObservability**, not HexaKit `Metron/` or workspace `metrickit`.
+2. Do not add new HexaKit path dependencies on `Metron/`.
+3. See absorption doc for crate name mapping (`metrickit` → `phenotype-metrics`).
+
+## For HexaKit maintainers
+
+- Wave A observability lane — do not relocate other observability crates in this PR.
+- Remove this stub directory once downstream references are cleared (follow-up PR).

--- a/Traceon/MIGRATED.md
+++ b/Traceon/MIGRATED.md
@@ -1,0 +1,23 @@
+# Migration: Traceon → PhenoObservability
+
+**Date:** 2026-06-17  
+**Disposition row:** HexaKit DISPOSITION #49 — `Traceon/`  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Absorption map:** [wave-a-absorption.md](https://github.com/KooshaPari/PhenoObservability/blob/main/docs/disposition/wave-a-absorption.md)
+
+## What changed
+
+- This path received a **redirect stub** per [crate relocation runbook step 6](../../docs/operations/crate-relocation-runbook.md).
+- Canonical distributed tracing ownership moves to **`PhenoObservability`** (`crates/tracingkit`; HexaKit `Traceon/` workspace member).
+- **Source is retained** in HexaKit for this wave — removal follows downstream repoint (runbook steps 4–5, 7).
+
+## For consumers
+
+1. Depend on tracing from **PhenoObservability** `tracingkit`, not HexaKit `Traceon/`.
+2. Do not add new HexaKit path dependencies on `Traceon/`.
+3. Crate name in HexaKit workspace is `tracingkit`; canonical home is `PhenoObservability/crates/tracingkit`.
+
+## For HexaKit maintainers
+
+- Wave A observability lane — do not relocate other observability crates in this PR.
+- Remove this stub directory once downstream references are cleared (follow-up PR).

--- a/crates/phenotype-health/MIGRATED.md
+++ b/crates/phenotype-health/MIGRATED.md
@@ -1,0 +1,22 @@
+# Migration: phenotype-health → PhenoObservability
+
+**Date:** 2026-06-17  
+**Disposition row:** HexaKit DISPOSITION #22 — `crates/phenotype-health`  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Absorption map:** [wave-a-absorption.md](https://github.com/KooshaPari/PhenoObservability/blob/main/docs/disposition/wave-a-absorption.md)
+
+## What changed
+
+- This path received a **redirect stub** per [crate relocation runbook step 6](../../docs/operations/crate-relocation-runbook.md).
+- Canonical health-check primitives ownership moves to **`PhenoObservability`** (`rust/phenotype-health` and adapters).
+- **Source is retained** in HexaKit for this wave — removal follows downstream repoint (runbook steps 4–5, 7).
+
+## For consumers
+
+1. Depend on `phenotype-health` from **PhenoObservability**, not HexaKit path deps.
+2. Axum/CLI adapters live under `PhenoObservability/rust/phenotype-health-axum` and `phenotype-health-cli`.
+
+## For HexaKit maintainers
+
+- Wave A observability lane — do not relocate other observability crates in this PR.
+- Remove this stub directory once downstream references are cleared (follow-up PR).

--- a/crates/phenotype-logging/MIGRATED.md
+++ b/crates/phenotype-logging/MIGRATED.md
@@ -1,0 +1,22 @@
+# Migration: phenotype-logging → PhenoObservability
+
+**Date:** 2026-06-17  
+**Disposition row:** HexaKit DISPOSITION #26 — `crates/phenotype-logging`  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Absorption map:** [wave-a-absorption.md](https://github.com/KooshaPari/PhenoObservability/blob/main/docs/disposition/wave-a-absorption.md)
+
+## What changed
+
+- This path received a **redirect stub** per [crate relocation runbook step 6](../../docs/operations/crate-relocation-runbook.md).
+- Canonical logging facade ownership moves to **`PhenoObservability`** (`rust/phenotype-logging`).
+- **Source is retained** in HexaKit for this wave — removal follows downstream repoint (runbook steps 4–5, 7).
+
+## For consumers
+
+1. Depend on `phenotype-logging` from **PhenoObservability**, not HexaKit path deps.
+2. Do not add new workspace or path dependencies on `HexaKit/crates/phenotype-logging`.
+
+## For HexaKit maintainers
+
+- Wave A observability lane — do not relocate other observability crates in this PR.
+- Remove this stub directory once downstream references are cleared (follow-up PR).

--- a/crates/phenotype-sentry-config/MIGRATED.md
+++ b/crates/phenotype-sentry-config/MIGRATED.md
@@ -1,0 +1,22 @@
+# Migration: phenotype-sentry-config → PhenoObservability
+
+**Date:** 2026-06-17  
+**Disposition row:** HexaKit DISPOSITION #35 — `crates/phenotype-sentry-config`  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Absorption map:** [wave-a-absorption.md](https://github.com/KooshaPari/PhenoObservability/blob/main/docs/disposition/wave-a-absorption.md)
+
+## What changed
+
+- This path received a **redirect stub** per [crate relocation runbook step 6](../../docs/operations/crate-relocation-runbook.md).
+- Canonical Sentry configuration ownership moves to **`PhenoObservability`** (planned `rust/phenotype-sentry-config`).
+- **Source is retained** in HexaKit for this wave — removal follows downstream repoint (runbook steps 4–5, 7).
+
+## For consumers
+
+1. Depend on Sentry init helpers from **PhenoObservability** once the target crate lands — not HexaKit path deps.
+2. Do not add new workspace or path dependencies on `HexaKit/crates/phenotype-sentry-config`.
+
+## For HexaKit maintainers
+
+- Wave A observability lane — do not relocate other observability crates in this PR.
+- Remove this stub directory once downstream references are cleared (follow-up PR).

--- a/crates/phenotype-telemetry/MIGRATED.md
+++ b/crates/phenotype-telemetry/MIGRATED.md
@@ -1,0 +1,22 @@
+# Migration: phenotype-telemetry → PhenoObservability
+
+**Date:** 2026-06-17  
+**Disposition row:** HexaKit DISPOSITION #39 — `crates/phenotype-telemetry`  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Absorption map:** [wave-a-absorption.md](https://github.com/KooshaPari/PhenoObservability/blob/main/docs/disposition/wave-a-absorption.md)
+
+## What changed
+
+- This path received a **redirect stub** per [crate relocation runbook step 6](../../docs/operations/crate-relocation-runbook.md).
+- Canonical telemetry facade ownership moves to **`PhenoObservability`** (`rust/phenotype-telemetry`).
+- **Source is retained** in HexaKit for this wave — removal follows downstream repoint (runbook steps 4–5, 7).
+
+## For consumers
+
+1. Depend on `phenotype-telemetry` from **PhenoObservability**, not HexaKit path deps.
+2. Do not add new workspace or path dependencies on `HexaKit/crates/phenotype-telemetry`.
+
+## For HexaKit maintainers
+
+- Wave A observability lane — do not relocate other observability crates in this PR.
+- Remove this stub directory once downstream references are cleared (follow-up PR).

--- a/docs/boundary/DISPOSITION.md
+++ b/docs/boundary/DISPOSITION.md
@@ -105,11 +105,11 @@ Dispositions map to the **[charter]** target topology:
 | 19 | `crates/phenotype-event-bus` | Event bus abstractions | **DECOMPOSE** | new `phenotype-events` repo | Domain event primitives; "Eventra" README already declares migration to PhenoEvents. |
 | 20 | `crates/phenotype-event-sourcing` | Event sourcing | **DECOMPOSE** | new `phenotype-events` repo | Sibling of #19; both belong in the events SDK. |
 | 21 | `crates/phenotype-git-core` | Git utilities | **DYNAMIC-KEEP** | `phenoShared` | Cross-cutting CLI/dev tool; no standalone-repo governance justified. |
-| 22 | `crates/phenotype-health` | Health-check primitives | **ABSORB** | `PhenoObservability` | Health checks are observability-adjacent (same family as metrics/logging/tracing). |
+| 22 | `crates/phenotype-health` | Health-check primitives | **ABSORB** | `PhenoObservability` | Health checks are observability-adjacent (same family as metrics/logging/tracing). **Wave A (2026-06-17):** `MIGRATED.md` stub added (runbook step 6); source retained pending repoint. |
 | 23 | `crates/phenotype-http-client-core` | HTTP client core | **ABSORB** | `ResilienceKit` | Charter §Decomposition map explicit: "http-client-core → ResilienceKit". |
 | 24 | `crates/phenotype-infrastructure` | Infra umbrella crate | **DYNAMIC-KEEP** | `phenoShared` | Umbrella of cross-cutting infra; charter: too-small-bits → phenoShared. |
 | 25 | `crates/phenotype-iter` | Iterator utilities | **DYNAMIC-KEEP** | `phenoShared` | Tiny; no standalone-repo governance justified. |
-| 26 | `crates/phenotype-logging` | Logging facade | **ABSORB** | `PhenoObservability` | Charter target: observability owns logging. |
+| 26 | `crates/phenotype-logging` | Logging facade | **ABSORB** | `PhenoObservability` | Charter target: observability owns logging. **Wave A (2026-06-17):** `MIGRATED.md` stub added (runbook step 6); source retained pending repoint. |
 | 27 | `crates/phenotype-macros` | Proc-macros (general) | **DYNAMIC-KEEP** | `phenoShared` | Cross-cutting proc-macro crate; too small. |
 | 28 | `crates/phenotype-mcp` | MCP primitives | **ABSORB** | `McpKit` (or `PhenoMCP`) | Charter target: McpKit owns MCP domain. |
 | 29 | `crates/phenotype-policy-engine` | Policy engine | **DECOMPOSE** | new `phenotype-policy` repo | Single coherent domain; absorbs casbin-wrapper (#6). |
@@ -118,11 +118,11 @@ Dispositions map to the **[charter]** target topology:
 | 32 | `crates/phenotype-process` | Process spawning utilities | **DYNAMIC-KEEP** | `phenoShared` | Cross-cutting runtime helper; too small. |
 | 33 | `crates/phenotype-project-registry` | Project registry types | **DYNAMIC-KEEP** | `phenoShared` | Cross-cutting; too small. |
 | 34 | `crates/phenotype-security-aggregator` | Security aggregation | **ABSORB** | `Authvault` (AuthKit) | Security is auth's neighbor domain; charter: secret/security → AuthKit. |
-| 35 | `crates/phenotype-sentry-config` | Sentry config helper | **ABSORB** | `PhenoObservability` | Sentry is an observability backend; belongs with the observability SDK. |
+| 35 | `crates/phenotype-sentry-config` | Sentry config helper | **ABSORB** | `PhenoObservability` | Sentry is an observability backend; belongs with the observability SDK. **Wave A (2026-06-17):** `MIGRATED.md` stub added (runbook step 6); source retained pending repoint. |
 | 36 | `crates/phenotype-shared-config` | Shared config types | **DYNAMIC-KEEP** | `phenoShared` | Cross-cutting config; too small. |
 | 37 | `crates/phenotype-state-machine` | State machine primitives | **DECOMPOSE** | new `phenotype-state-machine` repo | Single coherent domain primitive. |
 | 38 | `crates/phenotype-string` | String utilities | **DYNAMIC-KEEP** | `phenoShared` | Tiny; too small. |
-| 39 | `crates/phenotype-telemetry` | Telemetry facade | **ABSORB** | `PhenoObservability` | Charter target: observability owns telemetry (logging/tracing/metrics/health). |
+| 39 | `crates/phenotype-telemetry` | Telemetry facade | **ABSORB** | `PhenoObservability` | Charter target: observability owns telemetry (logging/tracing/metrics/health). **Wave A (2026-06-17):** `MIGRATED.md` stub added (runbook step 6); source retained pending repoint. |
 | 40 | `crates/phenotype-test-infra` | Test infra utilities | **ABSORB** | `TestingKit` | Charter target: TestingKit. |
 | 41 | `crates/phenotype-test-fixtures` | Test fixtures | **ABSORB** | `TestingKit` | Sibling of #40; relocate with test-infra. |
 | 42 | `crates/phenotype-time` | Time utilities | **DYNAMIC-KEEP** | `phenoShared` | Tiny; too small. |
@@ -131,8 +131,8 @@ Dispositions map to the **[charter]** target topology:
 | 45 | `crates/settly` | Settings management (validation, versioning, migration, postgres, redis) | **DECOMPOSE** | new `phenotype-settings` repo | Substantial single-domain crate (postgres + redis deps); not config-core. |
 | 46 | `crates/stashly` | Universal caching (TTL, multi-tier, singleflight) | **DECOMPOSE** | new `phenotype-cache` repo (or **ABSORB** → `ResilienceKit`) | Charter mentions rate-limit; cache is adjacent. Promoting to dedicated repo is cleaner given crate size; second choice: ResilienceKit. |
 | 47 | `crates/focalpoint` | Excluded from workspace (867 MB vendor; "pending manual absorption" per `[workspace] exclude`) | **DECOMPOSE** | new `phenotype-focalpoint` repo | Not present in shallow clone; workspace self-documents pending relocation. |
-| 48 | `Metron/` (workspace member) | Metrics collection (Prometheus, StatsD, JSON exporters) | **ABSORB** | `PhenoObservability` | README: "Metron is the observability backbone for all Phenotype services". |
-| 49 | `Traceon/` (workspace member) | Distributed tracing (OpenTelemetry, OTLP, Jaeger, Zipkin) | **ABSORB** | `PhenoObservability` | Charter + HexaKit BOUNDARY.md: "Telemetry → PhenoObservability / Tracely". |
+| 48 | `Metron/` (workspace member) | Metrics collection (Prometheus, StatsD, JSON exporters) | **ABSORB** | `PhenoObservability` | README: "Metron is the observability backbone for all Phenotype services". **Wave A (2026-06-17):** `MIGRATED.md` stub added (runbook step 6); source retained pending repoint. |
+| 49 | `Traceon/` (workspace member) | Distributed tracing (OpenTelemetry, OTLP, Jaeger, Zipkin) | **ABSORB** | `PhenoObservability` | Charter + HexaKit BOUNDARY.md: "Telemetry → PhenoObservability / Tracely". **Wave A (2026-06-17):** `MIGRATED.md` stub added (runbook step 6); source retained pending repoint. |
 | 50 | `forgecode-fork/` (workspace member) | Fork of `forgecode` code generator (Phenotype-specific transforms) | **ABSORB** | `HexaKit` (scaffolding-gen) | It's a code generator; scaffolding is the natural home (or stay as a separate fork repo if upstream sync matters). |
 | 51 | `libs/nexus` (workspace member) | Service registry + discovery | **DECOMPOSE** | new `nexus` repo (README already points at `KooshaPari/nexus`) | The crate's own README documents it as a standalone repo. |
 | 52–56 | `agileplus/crates/agileplus-benchmarks`, `agileplus-domain`, `agileplus-events`, `agileplus-graph`, `agileplus-sqlite`, `agileplus-triage` | AgilePlus platform sub-crates | **DECOMPOSE** | `agileplus` repo (its own platform) | The `agileplus/` umbrella is already a separate platform concern; sub-crates stay together as one platform repo. |


### PR DESCRIPTION
## **User description**
## Summary
- Add MIGRATED.md redirect stubs (runbook step 6) for Metron/, Traceon/, and phenotype-{logging,telemetry,health,sentry-config}
- Source trees retained — stubs only, no deletion
- Update DISPOSITION.md row notes for rows #22, #26, #35, #39, #48, #49

## Test plan
- [x] MIGRATED.md present in all six paths
- [x] DISPOSITION rationale notes updated
- [ ] Paired PhenoObservability absorption doc PR merged or linked

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add migration stubs for observability crates moving to PhenoObservability**

### What Changed
- Added `MIGRATED.md` stub pages for health, logging, telemetry, metrics, tracing, and Sentry config paths to point users to PhenoObservability
- Clarified that HexaKit keeps the source for now and that downstream links should be updated before removal
- Updated the disposition table to note the Wave A migration status for each affected path

### Impact
`✅ Clearer migration guidance for observability users`
`✅ Fewer broken links during the repo move`
`✅ Safer downstream repointing before source removal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
