### PR TITLE
chore(hexakit): P0 Metron + agileplus workspace eviction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ authors = ["kooshapari"]
 resolver = "2"
 exclude = [
   "crates/focalpoint",  # 867MB repo with vendor dir; fetch too large for subtree-add; pending manual absorption
+  "Metron",             # archived → PhenoObservability crates/metrickit (2026-06-17)
+  "agileplus",          # canonical → KooshaPari/AgilePlus (2026-06-17)
 ]
 members = [
   "crates/hexakit-cli",
@@ -59,16 +61,9 @@ members = [
   "crates/phenotype-xdd-lib",
   "crates/settly",
   "crates/stashly",
-  "Metron",
   "forgecode-fork",
   "libs/nexus",
   "libs/phenotype-config-core",
-  "agileplus/crates/agileplus-benchmarks",
-  "agileplus/crates/agileplus-domain",
-  "agileplus/crates/agileplus-events",
-  "agileplus/crates/agileplus-graph",
-  "agileplus/crates/agileplus-sqlite",
-  "agileplus/crates/agileplus-triage",
 ]
 [workspace.dependencies]
 sentry = "0.34"

--- a/Metron/README.md
+++ b/Metron/README.md
@@ -7,6 +7,12 @@
 
 # Metron
 
+> **MIGRATED (2026-06-17):** Canonical metrics implementation is
+> [`PhenoObservability/crates/metrickit`](https://github.com/KooshaPari/PhenoObservability/tree/main/crates/metrickit).
+> Source repo [`KooshaPari/Metron`](https://github.com/KooshaPari/Metron) is archived.
+> This tree is a retired audit copy — not a workspace member. Scaffold mirror:
+> `templates/hexagon/rust/metrickit/`.
+
 **Status:** maintenance
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/agileplus/README.md
+++ b/agileplus/README.md
@@ -1,3 +1,7 @@
+> **MIGRATED (2026-06-17):** Canonical AgilePlus workspace is
+> [`KooshaPari/AgilePlus`](https://github.com/KooshaPari/AgilePlus).
+> This subtree is a retired audit copy — not a HexaKit workspace member.
+
 # repos — CodeProjects/Phenotype organizational shelf
 
 This is the **repos shelf**: a polyrepo containing ~30 independent projects


### PR DESCRIPTION
## **User description**
## Summary
- Remove `Metron` and `agileplus/crates/*` from workspace `members` (BOUNDARY_OWNERS P0).
- Add `exclude` entries; README redirect stubs point to PhenoObservability metrickit and AgilePlus.

## Test plan
- [ ] `cargo check --workspace` (smaller member set)
- [x] Trees preserved for audit; no file deletion


___

## **CodeAnt-AI Description**
**Remove archived Metron and AgilePlus trees from the active workspace**

### What Changed
- Metron and AgilePlus are no longer treated as active workspace projects
- Their README files now clearly point to the canonical repositories and say these trees are retired audit copies
- The root workspace now skips the archived trees so they no longer affect workspace-wide commands

### Impact
`✅ Fewer workspace build failures from archived projects`
`✅ Clearer guidance on where to find the active Metron and AgilePlus code`
`✅ Faster workspace scans for active Rust projects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
