### PR TITLE
docs(eco): harness API v0 adapter stubs

### DIFF
--- a/docs/contracts/adapters/cursor-agent.md
+++ b/docs/contracts/adapters/cursor-agent.md
@@ -1,0 +1,32 @@
+# cursor-agent adapter (v0 stub)
+
+**Harness ID:** `cursor-agent`  
+**Status:** Phase 1b stub — dispatch surface not yet wired in `hexakit harness`  
+**Contract:** [Harness API](../harness-api.md)
+
+Compatible fallback harness for bounded lane work inside Cursor IDE agent sessions. Implements the four adapter operations: `dispatch`, `poll`, `cancel`, `capabilities`.
+
+## Routing
+
+| Lane class | Worktree | Lock |
+|------------|----------|------|
+| `MUTATE_RELOCATE` | Required | 1/repo + global cargo |
+| `MUTATE_SCAFFOLD` | Single branch | 1/repo |
+
+Used when `forge` is unavailable or when a lane is scoped to IDE-native agent tooling. See [lane routing](../harness-api.md#lane-routing-adr-eco-007).
+
+## Capabilities (v0)
+
+| Field | Value |
+|-------|-------|
+| `modes` | `read-only`, `write` |
+| `max_parallel` | 1 (per lane) |
+| `supported_profiles` | `codex`, `claude` |
+
+## HarnessProfile mapping
+
+At dispatch, HexaKit maps lane `harness: "cursor-agent"` to a [HarnessProfile](https://github.com/KooshaPari/thegent/blob/main/contracts/provider-bridge/schema/harness-profile.schema.json) with `defaults.intent_capability: tool_execution` and `defaults.latency_tier: interactive`. Tool policy inherits from session AACP bundle when present.
+
+## Example lane
+
+[cursor-lane.json](../../lanes/examples/cursor-lane.json)

--- a/docs/contracts/adapters/forge.md
+++ b/docs/contracts/adapters/forge.md
@@ -1,0 +1,36 @@
+# forge adapter (v0 stub)
+
+**Harness ID:** `forge`  
+**Status:** Phase 1b stub — dispatch surface not yet wired in `hexakit harness`  
+**Contract:** [Harness API](../harness-api.md)
+
+Primary disposition harness for ecosystem relocation and wide read-audit fan-out. Implements the four adapter operations: `dispatch`, `poll`, `cancel`, `capabilities`.
+
+## Routing
+
+| Lane class | Worktree | Lock |
+|------------|----------|------|
+| `MUTATE_RELOCATE` | Required | 1/repo + global cargo |
+| `READ_AUDIT` | Optional | none (up to 18-wide parallel) |
+
+See [ADR-ECO-007 lane routing](../harness-api.md#lane-routing-adr-eco-007) in the Harness API.
+
+## Capabilities (v0)
+
+| Field | Value |
+|-------|-------|
+| `modes` | `read-only`, `write`, `full` |
+| `max_parallel` | 18 |
+| `supported_profiles` | `codex`, `claude`, `droid` |
+
+## HarnessProfile mapping
+
+At dispatch, HexaKit maps lane `harness: "forge"` to a [HarnessProfile](https://github.com/KooshaPari/thegent/blob/main/contracts/provider-bridge/schema/harness-profile.schema.json) with `defaults.intent_capability: tool_execution` and `defaults.latency_tier: interactive`. Policy overrides inherit from the lane AACP bundle when present.
+
+## Session pattern
+
+Fan-out sessions use `.cursor/skills/forge-fanout/SKILL.md` — detached launcher, resource-lock discipline, and 20-wide DAG recipe. HexaKit adapters wrap this surface; they do not reimplement provider routing.
+
+## Example lane
+
+[forge-lane.json](../../lanes/examples/forge-lane.json)

--- a/docs/contracts/adapters/thegent.md
+++ b/docs/contracts/adapters/thegent.md
@@ -1,0 +1,36 @@
+# thegent adapter (v0 stub)
+
+**Harness ID:** `thegent`  
+**Status:** Phase 1b stub — dispatch surface not yet wired in `hexakit harness`  
+**Contract:** [Harness API](../harness-api.md)
+
+Python harness adapter backed by thegent provider-bridge. Wraps thegent's harness surface; HexaKit does not reimplement provider routing. Implements the four adapter operations: `dispatch`, `poll`, `cancel`, `capabilities`.
+
+## Routing
+
+| Lane class | Worktree | Lock |
+|------------|----------|------|
+| `LONG_VERIFY` | Required | session (`--owner`) |
+
+Fallback for `MUTATE_RELOCATE` and `READ_AUDIT` when primary harness is unavailable. See [lane routing](../harness-api.md#lane-routing-adr-eco-007).
+
+## Reference implementation
+
+thegent exposes:
+
+- `agent_executor(agent_id, prompt, context) → ExecutionResult`
+- `create_agent_executor(cwd, mode, timeout, model, agent_map) → Callable`
+
+Documented at `thegent/docs/reference/api/harness_api.md`.
+
+## HarnessProfile
+
+Each dispatch carries a [HarnessProfile](https://github.com/KooshaPari/thegent/blob/main/contracts/provider-bridge/schema/harness-profile.schema.json) validated against the upstream schema. HexaKit maps lane-level `harness: "thegent"` at dispatch time; `policy_overrides` and `tool_policy` inherit from the session AACP bundle when present.
+
+## Capabilities (v0)
+
+| Field | Value |
+|-------|-------|
+| `modes` | `read-only`, `write`, `full` |
+| `max_parallel` | 4 |
+| `supported_profiles` | `codex`, `claude`, `droid`, `antigma`, `codex_alt` |

--- a/docs/contracts/lanes/examples/cursor-lane.json
+++ b/docs/contracts/lanes/examples/cursor-lane.json
@@ -1,0 +1,29 @@
+{
+  "lane_id": "wave-b-wp01-scaffold",
+  "disposition_ids": [12],
+  "fsm_state": "ready",
+  "repo": "KooshaPari/HexaKit",
+  "worktree": "HexaKit-wtrees/scaffold-spec",
+  "branch": "feat/hexakit-scaffold-init",
+  "owns": ["docs/contracts/**", "templates/**"],
+  "forbidden_paths": ["crates/**", "Cargo.lock"],
+  "harness": "cursor-agent",
+  "harness_compat": ["forge", "thegent", "codex-fork"],
+  "aadp": {
+    "session_id": "20260617-eco-wave-b",
+    "context_bundle_version": "1.1",
+    "agent_context_bundle_hashes": []
+  },
+  "verify": [
+    "bun run tools/check-ecosystem.ts --map-only",
+    "cargo check --workspace"
+  ],
+  "exit_gate": {
+    "pr_merged": true,
+    "fsm_state": "done",
+    "watcher_pass": true,
+    "fr_tags": ["FR-ECO-007"]
+  },
+  "lane_class": "MUTATE_SCAFFOLD",
+  "notes": "Example cursor-agent lane for contract scaffold work (Harness API v0 stub)."
+}

--- a/docs/contracts/lanes/examples/forge-lane.json
+++ b/docs/contracts/lanes/examples/forge-lane.json
@@ -1,0 +1,30 @@
+{
+  "lane_id": "wave-a-wp03-metron",
+  "disposition_ids": [48],
+  "fsm_state": "claimed",
+  "repo": "KooshaPari/PhenoObservability",
+  "worktree": "PhenoObservability-wtrees/wave-a",
+  "branch": "feat/obs-metron-relocate",
+  "owns": ["Metron/**"],
+  "forbidden_paths": [],
+  "harness": "forge",
+  "harness_compat": ["cursor-agent", "thegent", "codex-fork"],
+  "aadp": {
+    "session_id": "20260617-eco-wave-a",
+    "context_bundle_version": "1.1",
+    "agent_context_bundle_hashes": []
+  },
+  "verify": [
+    "cargo test -p metron",
+    "cargo test --workspace",
+    "bun run tools/check-ecosystem.ts --map-only"
+  ],
+  "exit_gate": {
+    "pr_merged": true,
+    "fsm_state": "done",
+    "watcher_pass": true,
+    "fr_tags": ["FR-ECO-012"]
+  },
+  "lane_class": "MUTATE_RELOCATE",
+  "notes": "Example forge lane for Metron crate relocation (Harness API v0 stub)."
+}


### PR DESCRIPTION
## **User description**
## Summary
- Add thin v0 adapter stubs for forge, cursor-agent, and thegent referencing the Harness API contract
- Add example lane descriptors (forge-lane.json, cursor-lane.json) validated against lanes/schema.json

## Test plan
- [ ] Verify adapter docs link correctly to harness-api.md and HarnessProfile schema
- [ ] Confirm lane examples conform to docs/contracts/lanes/schema.json required fields
- [ ] No runtime changes — documentation-only Phase 1b stub

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add v0 adapter docs and example lane files for Harness API stubs**

### What Changed
- Added documentation for the `forge`, `cursor-agent`, and `thegent` harness adapters, including their supported lane types, routing rules, and capabilities
- Added example lane JSON files for `forge` and `cursor-agent` so the documented contract has concrete sample data
- Clarified how each adapter maps lane harness values into a HarnessProfile and where fallback behavior applies

### Impact
`✅ Clearer harness setup guidance`
`✅ Easier validation of lane examples`
`✅ Faster onboarding for adapter authors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
