### PR TITLE
feat(crates): drain phenotype-security-aggregator from infrakit (P2, L5-110)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ exclude = [
   "crates/phenotype-state-machine",
   "crates/phenotype-policy-engine",
   # P3 wave 4 — security + macros + async-traits → phenoShared (contracts deferred: API diverge)
-  "crates/phenotype-security-aggregator",
   "crates/phenotype-async-traits",
   "crates/phenotype-macros",
   # Wave 12 — health traits + cache adapter → phenoShared (PO retains runtime extensions)
@@ -70,6 +69,7 @@ members = [
   "crates/phenotype-core",
   "crates/phenotype-infrastructure",
   "crates/phenotype-project-registry",
+  "crates/phenotype-security-aggregator",
   "crates/phenotype-xdd-lib",
   "forgecode-fork",
   "libs/nexus",
@@ -122,7 +122,7 @@ phenotype-logging = { git = "https://github.com/KooshaPari/phenoShared", branch 
 phenotype-time = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-state-machine = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-policy-engine = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
-phenotype-security-aggregator = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+phenotype-security-aggregator = { path = "crates/phenotype-security-aggregator" }
 phenotype-async-traits = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-macros = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-config-loader = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }

--- a/crates/phenotype-security-aggregator/Cargo.toml
+++ b/crates/phenotype-security-aggregator/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "phenotype-security-aggregator"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+
+[dependencies]
+chrono = { workspace = true }

--- a/crates/phenotype-security-aggregator/src/lib.rs
+++ b/crates/phenotype-security-aggregator/src/lib.rs
@@ -1,0 +1,260 @@
+//! Phenotype Security Aggregator
+//!
+//! Aggregates security alerts from multiple sources (Snyk, CodeQL, cargo-audit).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Severity levels for security findings
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Severity {
+    Critical,
+    High,
+    Medium,
+    Low,
+    Info,
+}
+
+impl Severity {
+    /// Get numeric value for sorting
+    pub fn numeric_value(&self) -> u8 {
+        match self {
+            Severity::Critical => 5,
+            Severity::High => 4,
+            Severity::Medium => 3,
+            Severity::Low => 2,
+            Severity::Info => 1,
+        }
+    }
+}
+
+/// A security alert finding
+#[derive(Debug, Clone)]
+pub struct Finding {
+    /// Unique identifier
+    pub id: String,
+    /// Alert title
+    pub title: String,
+    /// Alert description
+    pub description: String,
+    /// Severity level
+    pub severity: Severity,
+    /// Source system
+    pub source: String,
+    /// File path (if applicable)
+    pub file: Option<String>,
+    /// Line number (if applicable)
+    pub line: Option<u32>,
+    /// When the alert was created
+    pub created_at: DateTime<Utc>,
+    /// CWE ID (if applicable)
+    pub cwe_id: Option<String>,
+    /// CVSS score (if applicable)
+    pub cvss_score: Option<f32>,
+}
+
+/// Score for a specific dimension of security
+#[derive(Debug, Clone)]
+pub struct DimensionScore {
+    /// Dimension name
+    pub name: String,
+    /// Score value (0-100)
+    pub score: f32,
+    /// Related findings
+    pub findings: Vec<Finding>,
+}
+
+/// Source of the alert
+#[derive(Debug, Clone, PartialEq)]
+pub enum AlertSource {
+    Snyk,
+    CodeQL,
+    CargoAudit,
+    Dependabot,
+    Trivy,
+    Custom(String),
+}
+
+impl AlertSource {
+    /// Get short name for display
+    pub fn short_name(&self) -> &str {
+        match self {
+            AlertSource::Snyk => "SNYK",
+            AlertSource::CodeQL => "CODEQL",
+            AlertSource::CargoAudit => "CARGO",
+            AlertSource::Dependabot => "DEPND",
+            AlertSource::Trivy => "TRIVY",
+            AlertSource::Custom(s) => s.as_str(),
+        }
+    }
+}
+
+/// Security alert from external sources
+#[derive(Debug, Clone)]
+pub struct SecurityAlert {
+    pub id: String,
+    pub title: String,
+    pub severity: Severity,
+    pub source: AlertSource,
+    pub description: String,
+    pub remediation: Option<String>,
+    pub cve_id: Option<String>,
+    pub cwes: Vec<String>,
+    pub references: Vec<String>,
+    pub found_at: Instant,
+    pub raw_data: Value,
+}
+
+/// Boxed alert stream type for object safety.
+pub type BoxedAlertStream = Pin<Box<dyn Stream<Item = SecurityAlert> + Send + 'static>>;
+/// Aggregates security alerts from multiple sources
+pub struct SecurityAggregator {
+    sources: Vec<Box<dyn SecuritySource>>,
+}
+
+/// Trait for security alert sources
+pub trait SecuritySource: Send + Sync {
+    /// Fetch alerts from this source
+    fn fetch_alerts(&self, owner: &str, repo: &str) -> impl std::future::Future<Output = anyhow::Result<Vec<SecurityAlert>>> + Send;
+}
+
+impl SecurityAggregator {
+    /// Create a new aggregator
+    pub fn new() -> Self {
+        Self { sources: Vec::new() }
+    }
+
+    /// Add a security source
+    pub fn add_source(&mut self, source: impl SecuritySource + 'static) {
+        self.sources.push(Box::new(source));
+    }
+
+    /// Aggregate security score from all sources
+    pub async fn aggregate_security_score(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> anyhow::Result<DimensionScore> {
+        let mut all_alerts = Vec::new();
+
+        for source in &self.sources {
+            match source.fetch_alerts(owner, repo).await {
+                Ok(alerts) => all_alerts.extend(alerts),
+                Err(e) => tracing::warn!("Security source failed: {}", e),
+            }
+        }
+
+        // Calculate score based on severity counts
+        let critical = all_alerts
+            .iter()
+            .filter(|a| matches!(a.severity, Severity::Critical))
+            .count();
+        let high = all_alerts
+            .iter()
+            .filter(|a| matches!(a.severity, Severity::High))
+            .count();
+        let medium = all_alerts
+            .iter()
+            .filter(|a| matches!(a.severity, Severity::Medium))
+            .count();
+
+        let deduction = critical as f32 * 25.0 + high as f32 * 10.0 + medium as f32 * 2.0;
+        let score = (100.0_f32 - deduction).max(0.0);
+
+        let findings: Vec<Finding> = all_alerts
+            .iter()
+            .map(|a| Finding {
+                id: a.cve_id.clone().unwrap_or_else(|| a.title.clone()),
+                title: a.title.clone(),
+                description: a.description.clone(),
+                severity: a.severity,
+                source: a.source.short_name().to_string(),
+                file: None,
+                line: None,
+                created_at: a.detected_at,
+                cwe_id: None,
+                cvss_score: None,
+            })
+            .collect();
+
+        Ok(DimensionScore {
+            name: "security".to_string(),
+            score,
+            findings,
+        })
+    }
+}
+
+impl Default for SecurityAggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// GitHub Security API implementation
+pub struct GitHubSecuritySource {
+    client: reqwest::Client,
+    token: String,
+}
+
+impl GitHubSecuritySource {
+    /// Create a new GitHub security source
+    pub fn new(token: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            token,
+        }
+    }
+}
+
+impl SecuritySource for GitHubSecuritySource {
+    async fn fetch_alerts(&self, owner: &str, repo: &str) -> anyhow::Result<Vec<SecurityAlert>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/dependabot/alerts",
+            owner, repo
+        );
+
+        let _response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await?;
+
+        // Parse and transform to SecurityAlert
+        // TODO: Implement actual parsing
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_aggregator() {
+        let aggregator = SecurityAggregator::new();
+        assert!(aggregator.sources.is_empty());
+    }
+
+    #[test]
+    fn test_severity_numeric_value() {
+        assert_eq!(Severity::Critical.numeric_value(), 5);
+        assert_eq!(Severity::High.numeric_value(), 4);
+        assert_eq!(Severity::Medium.numeric_value(), 3);
+        assert_eq!(Severity::Low.numeric_value(), 2);
+        assert_eq!(Severity::Info.numeric_value(), 1);
+    }
+
+    #[test]
+    fn test_alert_source_short_name() {
+        assert_eq!(AlertSource::Snyk.short_name(), "SNYK");
+        assert_eq!(AlertSource::CodeQL.short_name(), "CODEQL");
+        assert_eq!(AlertSource::CargoAudit.short_name(), "CARGO");
+        assert_eq!(AlertSource::Dependabot.short_name(), "DEPND");
+        assert_eq!(AlertSource::Trivy.short_name(), "TRIVY");
+        assert_eq!(AlertSource::Custom("Custom".to_string()).short_name(), "Custom");
+    }
+}

--- a/docs/boundary/HexaKit.md
+++ b/docs/boundary/HexaKit.md
@@ -1,0 +1,46 @@
+<!--
+propagated-from: KooshaPari/phenotype-registry @ chore/l7-001-curation-snapshot
+date: 2026-06-17
+source-commit: a1aa44660
+do-not-edit-locally: regenerate via scripts/propagate-intent-to-repos.py
+                     or update in the source-of-truth registry repo
+-->
+---
+repo: "HexaKit"
+role: unknown
+status: active
+last_boundary_review: 2026-06-17
+review_cadence: 30d
+in_scope:
+  - "<to be filled>"
+out_of_scope:
+  - "<to be filled>"
+---
+
+# Boundary — HexaKit
+
+## In Scope
+
+<To be filled.>
+
+## Out of Scope
+
+| Not here | Lives in | Reason |
+| -------- | -------- | ------ |
+| <capability> | <other-repo-or-N/A> | <why> |
+
+## Boundary Crossings
+
+| Crossing | Direction | Surface | Status |
+| -------- | --------- | ------- | ------ |
+| <capability or interface> | <this-repo→other\|other→this-repo> | <Trait / HTTP / CLI / file / event> | <green\|amber\|red> |
+
+## Last Boundary Review
+
+**Date:** 2026-06-17
+**Reviewer:** forge subagent (L7-001 sweep)
+**Worklog / finding:** `worklogs/L7-001-intent-boundary-curation-2026-06-17.json`
+**Decisions:**
+- Initial scaffolding; needs human review.
+
+**Next review:** 2026-07-17

--- a/docs/intent/HexaKit.md
+++ b/docs/intent/HexaKit.md
@@ -1,0 +1,109 @@
+<!--
+propagated-from: KooshaPari/phenotype-registry @ chore/l7-001-curation-snapshot
+date: 2026-06-17
+source-commit: a1aa44660
+do-not-edit-locally: regenerate via scripts/propagate-intent-to-repos.py
+                     or update in the source-of-truth registry repo
+-->
+---
+repo: "HexaKit"
+aliases: []
+role: unknown
+status: active
+last_verified: 2026-06-17
+bound_prompts: 56
+bound_plans: 0
+bound_responses: 0
+device: macbook
+---
+
+# Intent — HexaKit
+
+## Intent Statement
+
+<To be filled in by hand from the most recent binding prompt. This repo is bound to 56 prompts, 0 plans, and 0 agent responses captured between 2025-08 and 2026-06-17.>
+
+## Bound Prompts
+
+| Date | Source | File | Tag |
+| ---- | ------ | ---- | --- |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/01ceef22fbc797ae.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/028b0eb6b4641137.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/0413b030363b75c2.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/0540744d17bef5cb.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/0a643041b672b648.md` | bugfix |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/0fac6fd84103d368.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/189bcbdb4349b336.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/21a4011dd8cae6d9.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/2850ac214a901ac5.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/2a7ebe4541ceae2c.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/2ab6fc0bce964914.md` | narrative |
+| 2026-04-25 | codex | `docs/curated-prompts/codex/2026-04/2bdf585d5779c1a0.md` | policy-setting |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/378b7225c5ee2e86.md` | idea |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/378d14983a070885.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/40727f30868c6f98.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/48a8824fdcd3a055.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/492e41c73a1fcdaa.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/4e5c4e745fccfccb.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/5bdc7b171562184c.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/6382c6cf10485c78.md` | implementation |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/66544e2875485cde.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/6c8d28f36d04831e.md` | implementation |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/7458bb3902ba7f6e.md` | policy-setting |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/751f5d590fc5a275.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/77c4b1607bda989d.md` | bugfix |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/78820a1071e35bca.md` | bugfix |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/807303598e202ff1.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/8088f18d7abdfb11.md` | implementation |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/85399cfaa13036c3.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/857f73b919ba4f25.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/8fa2f0a87550e3e7.md` | policy-setting |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/93b81dbc1584e378.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/943abcce94cbf239.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/95418246b0fac578.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/99842ab44a172d8f.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/a4b55dc214b2221c.md` | bugfix |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/a506f31bbcfff6ab.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/a917e3781f6687bd.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/aa0c806d3408b837.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/bbb4489cffdb4a6b.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/c086b697189d190b.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/d08f79e4a7b212d0.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/d17d661ebe7980ae.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/d681a00feb06cadc.md` | implementation |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/d99ba2f3b2366f98.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/de195821960155f3.md` | policy-setting |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/e2417d40adbc306e.md` | implementation |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/e4120563468f116e.md` | narrative |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/e42e4d15091143a6.md` | policy-setting |
+| ? | claude-code | `docs/curated-prompts/claude-code/unknown/e645d6404a5ddf52.md` | narrative |
+
+_…and 6 more. See `_bindings.json` for full list._
+
+## Bound Plans
+
+| Date | Source | File | Status |
+| ---- | ------ | ---- | ------ |
+
+## Bound Responses (specs, ideas, plans from agents)
+
+| Date | Source | File | Kind |
+| ---- | ------ | ---- | ---- |
+
+## Boundary
+
+See: [`docs/boundary/HexaKit.md`](../boundary/HexaKit.md)
+
+## Ecosystem Role
+
+<See `ECOSYSTEM_MAP.md` for the canonical ecosystem role.>
+
+## Open Questions
+
+- <To be filled from the latest prompt on this repo.>
+
+## Change Log
+
+| Date | Change | Worklog |
+| ---- | ------ | ------- |
+| 2026-06-17 | Initial binding (L7-001 sweep) | `worklogs/L7-001-intent-boundary-curation-2026-06-17.json` |


### PR DESCRIPTION
## **User description**
Drains `phenotype-security-aggregator` (260 LOC, substantive code) from `phenotype-infrakit` into HexaKit.

- Removed `crates/phenotype-security-aggregator` from HexaKit's workspace exclude list
- Added to workspace members
- Updated workspace dependency from git (broken phenoShared ref) to local path
- Crate has 260 LOC: SecurityAggregator, SecuritySource trait, GitHubSecuritySource, tests

Part of L5-110 infrakit drain plan.


___

## **CodeAnt-AI Description**
**Move the security alert aggregator into HexaKit and keep it usable from the local workspace**

### What Changed
- The security alert aggregator now lives in this repository instead of coming from the shared external source
- The workspace includes the crate again, so it can be built and used locally
- The crate provides a security score from multiple alert sources and returns the related findings
- Added repo intent and boundary docs for HexaKit

### Impact
`✅ Local builds for security alert aggregation`
`✅ Fewer dependency issues from the shared source`
`✅ Clearer HexaKit boundary documentation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
