### PR TITLE
chore(hexakit): repoint phenotype-logging to PhenoObservability (disposition #26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
@@ -806,6 +806,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1196,7 +1197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "phenotype-async-traits"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "pin-project",
 ]
@@ -1204,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "phenotype-cache-adapter"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "serde",
  "serde_json",
@@ -1233,7 +1234,7 @@ dependencies = [
 name = "phenotype-contract-adapters"
 version = "0.2.0"
 dependencies = [
- "phenotype-error-core",
+ "phenotype-error-core 0.2.0 (git+https://github.com/KooshaPari/phenotype-types?branch=main)",
  "serde",
 ]
 
@@ -1253,7 +1254,7 @@ dependencies = [
  "phenotype-cache-adapter",
  "phenotype-config-core",
  "phenotype-contract-adapters",
- "phenotype-error-core",
+ "phenotype-error-core 0.2.0 (git+https://github.com/KooshaPari/phenotype-types?branch=main)",
  "phenotype-errors",
  "phenotype-event-bus",
  "phenotype-health",
@@ -1281,12 +1282,31 @@ dependencies = [
 [[package]]
 name = "phenotype-error-core"
 version = "0.2.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "anyhow",
+ "chrono",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "phenotype-error-core"
+version = "0.2.0"
+source = "git+https://github.com/KooshaPari/phenotype-types?branch=main#dd14f735c373e66b1907b7d5d66d3e175abe1df2"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1302,10 +1322,10 @@ dependencies = [
 [[package]]
 name = "phenotype-errors"
 version = "0.2.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenotype-types?branch=main#dd14f735c373e66b1907b7d5d66d3e175abe1df2"
 dependencies = [
  "chrono",
- "phenotype-error-core",
+ "phenotype-error-core 0.2.0 (git+https://github.com/KooshaPari/phenotype-types?branch=main)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1314,11 +1334,11 @@ dependencies = [
 [[package]]
 name = "phenotype-event-bus"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
- "phenotype-error-core",
+ "phenotype-error-core 0.2.0 (git+https://github.com/KooshaPari/phenoShared?branch=main)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1333,7 +1353,7 @@ version = "0.2.0"
 [[package]]
 name = "phenotype-health"
 version = "0.2.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "chrono",
  "serde",
@@ -1344,9 +1364,9 @@ dependencies = [
 [[package]]
 name = "phenotype-http-client-core"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -1363,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "phenotype-policy-engine"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "dashmap 6.2.1",
  "regex",
@@ -1431,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "phenotype-state-machine"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "serde",
  "serde_json",
@@ -1453,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "phenotype-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/PhenoObservability?branch=main#42cb5adbc2be325f635209049a66f7bf4b3d087a"
+source = "git+https://github.com/KooshaPari/PhenoObservability?branch=main#a3cdb85b1644765390f729fdc94294a61bcde095"
 dependencies = [
  "chrono",
  "uuid",
@@ -1462,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "phenotype-time"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#6e05527d44b15cdbef7e5cda7869661900be9ea7"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#95d74795c77f7c554be2b5e42e8e3378cdab77bf"
 dependencies = [
  "chrono",
  "thiserror 2.0.18",
@@ -1774,6 +1794,45 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1858,6 +1917,7 @@ checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2061,6 +2121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2730,6 +2802,15 @@ name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ phenotype-errors = { git = "https://github.com/KooshaPari/phenotype-types", bran
 phenotype-event-bus = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-event-sourcing = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-http-client-core = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
-phenotype-logging = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+phenotype-logging = { git = "https://github.com/KooshaPari/PhenoObservability", branch = "main", package = "phenotype-logging" }
 phenotype-time = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-state-machine = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-policy-engine = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }

--- a/crates/phenotype-logging/MIGRATED.md
+++ b/crates/phenotype-logging/MIGRATED.md
@@ -1,19 +1,21 @@
 # Migration: phenotype-logging → PhenoObservability
 
-**Date:** 2026-06-17  
-**Disposition row:** HexaKit DISPOSITION #26 — `crates/phenotype-logging`  
-**Canonical repo:** https://github.com/KooshaPari/phenoShared  
-**Git pin:** HexaKit workspace `phenoShared` branch `main` (wave 3 #258)
+**Date:** 2026-06-18  
+**Disposition row:** HexaKit DISPOSITION #26 — Wave A  
+**Canonical repo:** https://github.com/KooshaPari/PhenoObservability  
+**Git pin:** `PhenoObservability` branch `main` (PhenoObservability#169)
 
 ## What changed
 
-- Implementation ownership is **phenoShared** (not PhenoObservability path dep).
 - Local source **pruned** wave 13 — this directory is a redirect stub only.
+- Canonical implementation at `PhenoObservability/rust/phenotype-logging`.
+- Repointed from interim **phenoShared** pin (HexaKit#258, phenoShared#177).
 
 ## For consumers
 
-1. Depend on `phenotype-logging` from **phenoShared** (git pin), not HexaKit path deps.
-2. Do not add new workspace or path dependencies on `HexaKit/crates/phenotype-logging`.
+```toml
+phenotype-logging = { git = "https://github.com/KooshaPari/PhenoObservability", branch = "main", package = "phenotype-logging" }
+```
 
 ## For HexaKit maintainers
 

--- a/docs/migrations/phase3-wave-ab-prune-2026-06-18.md
+++ b/docs/migrations/phase3-wave-ab-prune-2026-06-18.md
@@ -8,6 +8,7 @@
 |-------|--------|-------------|
 | `phenotype-sentry-config` | PhenoObservability | 35 |
 | `phenotype-telemetry` | PhenoObservability | 39 |
+| `phenotype-logging` | PhenoObservability | 26 |
 | `phenotype-contract` | TestingKit | 10 |
 | `phenotype-test-fixtures` | TestingKit | 41 |
 


### PR DESCRIPTION
## **User description**
## Summary
- Repoint workspace git pin from phenoShared to PhenoObservability rust/phenotype-logging
- Update MIGRATED.md stub and phase3 migration doc
- Prereq: PhenoObservability#169 merged (a3cdb85)

## Test plan
- [x] cargo check -p phenotype-core
- [ ] Registry id 26 fsm done after merge

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Point phenotype-logging to PhenoObservability**

### What Changed
- The workspace now pulls `phenotype-logging` from PhenoObservability instead of the interim phenoShared source
- The migration note now points consumers to the new canonical repository and git pin
- The phase 3 migration list now includes `phenotype-logging` under PhenoObservability

### Impact
`✅ Correct logging source in the workspace`
`✅ Fewer dependency mismatches during builds`
`✅ Clearer migration guidance for consumers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
