### PR TITLE
fix(rust): align tonic 0.14 with prost 0.14 in rust/ crate

### DIFF
--- a/agileplus-agents/Cargo.toml
+++ b/agileplus-agents/Cargo.toml
@@ -20,6 +20,7 @@ tokio-stream = "0.1"
 # gRPC / proto
 tonic = { version = "0.14", features = ["transport"] }
 tonic-health = "0.14"
+tonic-prost = "0.14"
 prost = "0.14"
 tonic-prost-build = "0.14"
 

--- a/agileplus-agents/Cargo.toml
+++ b/agileplus-agents/Cargo.toml
@@ -18,9 +18,10 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 
 # gRPC / proto
-tonic = { version = "0.12", features = ["transport"] }
-tonic-health = "0.12"
+tonic = { version = "0.14", features = ["transport"] }
+tonic-health = "0.14"
 prost = "0.14"
+tonic-build = "0.14"
 
 # Concurrency utilities
 dashmap = "6"

--- a/agileplus-agents/Cargo.toml
+++ b/agileplus-agents/Cargo.toml
@@ -21,7 +21,7 @@ tokio-stream = "0.1"
 tonic = { version = "0.14", features = ["transport"] }
 tonic-health = "0.14"
 prost = "0.14"
-tonic-build = "0.14"
+tonic-prost-build = "0.14"
 
 # Concurrency utilities
 dashmap = "6"

--- a/agileplus-agents/crates/agileplus-agent-service/Cargo.toml
+++ b/agileplus-agents/crates/agileplus-agent-service/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tonic-health = { workspace = true }
+tonic-prost = { workspace = true }
 prost = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }

--- a/agileplus-agents/crates/agileplus-agent-service/Cargo.toml
+++ b/agileplus-agents/crates/agileplus-agent-service/Cargo.toml
@@ -24,4 +24,4 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }

--- a/agileplus-agents/crates/agileplus-agent-service/build.rs
+++ b/agileplus-agents/crates/agileplus-agent-service/build.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|p| p.join("proto"))
         .expect("could not compute proto root path");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [dependencies]
 prost = "0.14"
 tonic = { version = "0.14", features = ["transport"] }
+tonic-prost = "0.14"
 
 [package.metadata.cargo-machete]
 ignored = ["prost"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,4 +15,4 @@ tonic = { version = "0.14", features = ["transport"] }
 ignored = ["prost"]
 
 [build-dependencies]
-tonic-build = "0.14"
+tonic-prost-build = "0.14"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,10 +9,10 @@ license = "MIT"
 
 [dependencies]
 prost = "0.14"
-tonic = { version = "0.12", features = ["transport"] }
+tonic = { version = "0.14", features = ["transport"] }
 
 [package.metadata.cargo-machete]
 ignored = ["prost"]
 
 [build-dependencies]
-tonic-build = "0.12"
+tonic-build = "0.14"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,5 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(


### PR DESCRIPTION
## **User description**
## Summary
- Bump tonic/tonic-build/tonic-health 0.12 -> 0.14 in rust/ and agileplus-agents
- Eliminates dual prost 0.13/0.14 graph breaking ci.yml Rust Quality after #274

## Test plan
- [ ] Rust Quality + Rust Build green on PR
- [ ] Merge when green

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Align Rust gRPC dependencies so builds stop failing on mixed protobuf versions**

### What Changed
- Updated the Rust workspace and agent crate to use the same newer gRPC libraries throughout
- Removed the older gRPC versions that could pull in conflicting protobuf dependencies and break Rust checks
- Kept the protobuf library on the matching version so code generation and builds stay in sync

### Impact
`✅ Fewer Rust CI failures`
`✅ Fewer protobuf version conflicts`
`✅ More reliable Rust builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
