### PR TITLE
feat(wave5): drain phenoShared git pins to DOMAIN_ROLES owners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,16 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -511,6 +521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +574,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "forgecode-fork"
 version = "0.2.0"
 dependencies = [
@@ -597,6 +631,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,7 +666,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -810,6 +865,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,9 +898,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1118,6 +1191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1215,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1160,10 +1256,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1317,6 +1450,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "phenotype-error-core"
+version = "0.2.0"
+source = "git+https://github.com/KooshaPari/ResilienceKit?branch=main#c1ca60cf59a7bf6ea553f9818520b20f11a06d0b"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "phenotype-error-macros"
 version = "0.2.0"
 dependencies = [
@@ -1370,10 +1514,15 @@ dependencies = [
 
 [[package]]
 name = "phenotype-http-client-core"
-version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#5c3021bc7fd1073561e1bd128235763f44e9da66"
+version = "0.2.0"
+source = "git+https://github.com/KooshaPari/ResilienceKit?branch=main#c1ca60cf59a7bf6ea553f9818520b20f11a06d0b"
 dependencies = [
- "reqwest 0.13.4",
+ "async-trait",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1389,15 +1538,18 @@ dependencies = [
 
 [[package]]
 name = "phenotype-policy-engine"
-version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#5c3021bc7fd1073561e1bd128235763f44e9da66"
+version = "0.2.0"
+source = "git+https://github.com/KooshaPari/ResilienceKit?branch=main#c1ca60cf59a7bf6ea553f9818520b20f11a06d0b"
 dependencies = [
- "dashmap 6.2.1",
+ "async-trait",
+ "dashmap 5.5.3",
+ "phenotype-error-core 0.2.0 (git+https://github.com/KooshaPari/ResilienceKit?branch=main)",
  "regex",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "tokio",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1457,8 +1609,8 @@ dependencies = [
 
 [[package]]
 name = "phenotype-state-machine"
-version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#5c3021bc7fd1073561e1bd128235763f44e9da66"
+version = "0.2.0"
+source = "git+https://github.com/KooshaPari/ResilienceKit?branch=main#c1ca60cf59a7bf6ea553f9818520b20f11a06d0b"
 dependencies = [
  "serde",
  "serde_json",
@@ -1480,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "phenotype-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/KooshaPari/PhenoObservability?branch=main#a3cdb85b1644765390f729fdc94294a61bcde095"
+source = "git+https://github.com/KooshaPari/PhenoObservability?branch=main#c0ca676f2085360678fc113f482bf71bc5d460da"
 dependencies = [
  "chrono",
  "uuid",
@@ -1807,16 +1959,21 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1827,13 +1984,16 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1959,7 +2119,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2047,7 +2207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2289,6 +2449,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2573,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2681,6 +2872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2982,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,7 +3038,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2871,6 +3081,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ exclude = [
   # P3 wave 1 — error crates canonical in phenoShared (API-compatible)
   "crates/phenotype-error-core",
   "crates/phenotype-errors",
-  # P3 wave 2 — event + http-client crates canonical in phenoShared
+  # P3 wave 2 — event crates interim phenoShared (Eventra absorb pending); http-client → ResilienceKit
   "crates/phenotype-event-bus",
   "crates/phenotype-event-sourcing",
   "crates/phenotype-http-client-core",
-  # P3 wave 3 — infra primitives canonical in phenoShared
+  # P3 wave 3 — logging → PO; time interim phenoShared; state-machine + policy → ResilienceKit
   "crates/phenotype-logging",
   "crates/phenotype-time",
   "crates/phenotype-state-machine",
@@ -32,7 +32,7 @@ exclude = [
   # P3 wave 4 — security + macros + async-traits → phenoShared (contracts deferred: API diverge)
   "crates/phenotype-async-traits",
   "crates/phenotype-macros",
-  # Wave 12 — health traits + cache adapter → phenoShared (PO retains runtime extensions)
+  # Wave 12 — health traits interim phenoShared (PO runtime differs); cache adapter stub interim
   "crates/phenotype-health",
   "crates/phenotype-cache-adapter",
   # eco-consolidate — config-loader, mcp
@@ -40,7 +40,7 @@ exclude = [
   "crates/phenotype-mcp",
   # Wave 13 lane B — test infra → TestingKit
   "crates/phenotype-test-infra",
-  # Wave 13 lane C — contracts traits → phenoShared; adapters stay scaffold-local
+  # Wave 13 lane C — generic Contract trait interim phenoShared; slice crates → role owners
   "crates/phenotype-contracts",
   # Wave 13 lane D — cipher → Authvault
   "crates/cipher",
@@ -120,24 +120,34 @@ ulid = { version = "1", features = ["serde"] }
 
 # Phenotype internal crates
 arc-swap = "1"
-# phenoShared canonical (P3 waves 1–4, wave 12 health/cache)
+# phenoShared interim pins (ADR-ECO-014) — drain to DOMAIN_ROLES owners per wave 5+
 phenotype-error-core = { git = "https://github.com/KooshaPari/phenotype-types", branch = "main" }
 phenotype-errors = { git = "https://github.com/KooshaPari/phenotype-types", branch = "main" }
+# Eventra absorb pending — event-bus/sourcing remain phenoShared until landed on Eventra main
 phenotype-event-bus = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-event-sourcing = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
-phenotype-http-client-core = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+# ResilienceKit = phenotype-resilience DOMAIN_ROLES owner
+phenotype-http-client-core = { git = "https://github.com/KooshaPari/ResilienceKit", branch = "main" }
+phenotype-state-machine = { git = "https://github.com/KooshaPari/ResilienceKit", branch = "main" }
+phenotype-policy-engine = { git = "https://github.com/KooshaPari/ResilienceKit", branch = "main" }
 phenotype-logging = { git = "https://github.com/KooshaPari/PhenoObservability", branch = "main", package = "phenotype-logging" }
 phenotype-time = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
-phenotype-state-machine = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
-phenotype-policy-engine = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+# phenotype-rust-sdk repo not created — interim phenoShared per ADR-ECO-014
 phenotype-async-traits = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-macros = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-config-loader = { git = "https://github.com/KooshaPari/phenotype-config", branch = "main" }
 phenotype-mcp = { git = "https://github.com/KooshaPari/substrate", branch = "main" }
+# PO canonical runtime differs (HealthCheck vs HealthChecker) — traits interim phenoShared
 phenotype-health = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+# archive-if-unused stub — retain phenoShared pin until absorbed or HexaKit inline stub
 phenotype-cache-adapter = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-contract-adapters = { path = "crates/phenotype-contract-adapters" }
+# Contracts decompose: slice crates on role owners; generic Contract trait interim phenoShared
+phenotype-auth-contracts = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-auth-contracts" }
+phenotype-event-contracts = { git = "https://github.com/KooshaPari/Eventra", branch = "main", package = "phenotype-event-contracts" }
+phenotype-agent-contracts = { git = "https://github.com/KooshaPari/Agentora", branch = "main", package = "phenotype-agent-contracts" }
 phenotype-contracts = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+phenotype-security-aggregator = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-security-aggregator" }
 phenotype-test-infra = { git = "https://github.com/KooshaPari/TestingKit", branch = "main" }
 phenotype-cipher = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-cipher" }
 phenotype-crypto = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-crypto" }

--- a/crates/phenotype-contract-adapters/src/lib.rs
+++ b/crates/phenotype-contract-adapters/src/lib.rs
@@ -1,7 +1,7 @@
 //! HexaKit scaffold adapters for hexagonal ports.
 //!
 //! In-memory implementations used by `phenotype-core` re-exports. Canonical
-//! contract traits live in phenoShared `phenotype-contracts`.
+//! contract traits: slice crates on Authvault/Eventra/Agentora; generic `Contract` interim phenoShared.
 
 pub mod adapters;
 pub mod error;

--- a/docs/migrations/wave5-phenoshared-pin-drain-2026-06-19.md
+++ b/docs/migrations/wave5-phenoshared-pin-drain-2026-06-19.md
@@ -1,0 +1,37 @@
+# Wave 5 — phenoShared git pin drain (HexaKit)
+
+**Date:** 2026-06-19  
+**Branch:** `feat/wave5-phenoshared-pin-drain`  
+**ADR:** ADR-ECO-014-phenoshared-decompose  
+**Gate:** `gate-phenoshared` DELETE hold until interim pins drained
+
+## Drained to terminal DOMAIN_ROLES owners (verified on owner `main` via `gh`)
+
+| Workspace pin | Terminal owner | Repo path |
+|---------------|----------------|-----------|
+| `phenotype-http-client-core` | ResilienceKit (phenotype-resilience) | `crates/phenotype-http-client-core` |
+| `phenotype-state-machine` | ResilienceKit | `crates/phenotype-state-machine` |
+| `phenotype-policy-engine` | ResilienceKit | `crates/phenotype-policy-engine` |
+| `phenotype-auth-contracts` | Authvault | `rust/phenotype-auth-contracts` |
+| `phenotype-event-contracts` | Eventra | `rust/phenotype-event-contracts` |
+| `phenotype-agent-contracts` | Agentora | `rust/phenotype-agent-contracts` |
+| `phenotype-security-aggregator` | Authvault | `authkit/rust/phenotype-security-aggregator` |
+
+## Remaining phenoShared interim pins (blocked)
+
+| Pin | Blocker |
+|-----|---------|
+| `phenotype-event-bus`, `phenotype-event-sourcing` | Not on Eventra `main` (only `phenotype-event-contracts` landed) |
+| `phenotype-time` | Not on `phenotype-types` or `phenotype-config` `main` |
+| `phenotype-async-traits`, `phenotype-macros` | `phenotype-rust-sdk` repo does not exist |
+| `phenotype-health` | PO `rust/phenotype-health` API diverges (`HealthCheck` vs `HealthChecker`) |
+| `phenotype-cache-adapter` | archive-if-unused stub verdict — retain phenoShared until absorb |
+| `phenotype-contracts` | Generic `Contract` trait — interim until rust-sdk facade |
+| `phenotype-iter`, `phenotype-string`, `phenotype-validation` | Still only on phenoShared `main` |
+
+## Verification
+
+```bash
+cargo check -p phenotype-core
+rg 'KooshaPari/phenoShared' Cargo.toml
+```


### PR DESCRIPTION
## **User description**
## Summary
- Repoint 3 ResilienceKit crates (http-client-core, state-machine, policy-engine) from interim phenoShared pins
- Add terminal contract slice pins (Authvault auth-contracts, Eventra event-contracts, Agentora agent-contracts)
- Add Authvault security-aggregator workspace pin for excluded stub
- Document 10 remaining phenoShared interim pins blocked by missing owner crates or API diverge

## Drained pins (7)
- phenotype-http-client-core, phenotype-state-machine, phenotype-policy-engine -> ResilienceKit
- phenotype-auth-contracts, phenotype-security-aggregator -> Authvault
- phenotype-event-contracts -> Eventra
- phenotype-agent-contracts -> Agentora

## Remaining phenoShared pins (10)
event-bus, event-sourcing, time, async-traits, macros, health, cache-adapter, contracts (generic), iter, string, validation

## Test plan
- [x] cargo check -p phenotype-core
- [ ] Rust CI green

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Move several shared crate pins to their terminal owner repos**

### What Changed
- Repointed the core resilience crates to ResilienceKit, so builds now pull `http-client-core`, `state-machine`, and `policy-engine` from their owner repo
- Moved contract-related pins to their owner repos for Authvault, Eventra, and Agentora, including the security aggregator
- Left the remaining shared pins in phenoShared where the owner crate is not ready yet or the API still differs
- Updated the crate notes and added a migration doc that lists the drained pins, the blockers, and the verification steps

### Impact
`✅ Fewer shared-repo dependency pins`
`✅ Clearer crate ownership for future updates`
`✅ Easier tracking of remaining migration blockers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
