### PR TITLE
fix(hexakit): restore phenoShared git pin for phenotype-cache-adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,12 @@ dependencies = [
 
 [[package]]
 name = "phenotype-cache-adapter"
-version = "0.2.0"
+version = "0.1.0"
+source = "git+https://github.com/KooshaPari/phenoShared?branch=main#b45ca51dd57ddca5f6aeea138ea7c48cffd69034"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "phenotype-compliance-scanner"
@@ -1470,6 +1475,13 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "phenotype-security-aggregator"
+version = "0.1.0"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,8 +140,8 @@ phenotype-config-loader = { git = "https://github.com/KooshaPari/phenotype-confi
 phenotype-mcp = { git = "https://github.com/KooshaPari/substrate", branch = "main" }
 # ResilienceKit traits crate (HealthChecker API — PO runtime differs)
 phenotype-health = { git = "https://github.com/KooshaPari/ResilienceKit", branch = "main", package = "phenotype-health" }
-# archive-if-unused stub — HexaKit genesis path dep
-phenotype-cache-adapter = { path = "libs/phenotype-cache-adapter" }
+# archive-if-unused stub — retain phenoShared pin until absorbed (wave5b #278 regression fix)
+phenotype-cache-adapter = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
 phenotype-contract-adapters = { path = "crates/phenotype-contract-adapters" }
 # Contracts decompose: slice crates on role owners; generic Contract → phenotype-rust-sdk
 phenotype-auth-contracts = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-auth-contracts" }


### PR DESCRIPTION
## **User description**
## Summary

- Wave5b #278 regression: \phenotype-cache-adapter\ was repointed to missing \libs/phenotype-cache-adapter\ path
- Restores phenoShared interim git pin (archive-if-unused verdict; task #56 CacheAdapter re-export unblock)

## Context

Phase 4 wave 5 tasks 56-59 landed in #271/#276/#277/#278. This is the smallest follow-up to restore \cargo check -p phenotype-core\.

Does **not** duplicate #264/#267/#275.

## Test plan

- [x] \cargo check -p phenotype-core\ green locally

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Restore the cache adapter dependency so the workspace checks build again

### What Changed
- Switched the cache adapter back to the working phenoShared source after it was pointed at a missing local path
- This fixes the broken build check for phenotype-core caused by the bad dependency target

### Impact
`✅ Fewer broken workspace builds`
`✅ Restored phenotype-core checks`
`✅ Fewer dependency path failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
