### PR TITLE
fix(hexakit): drain last phenoShared pin via cache-adapter inline stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,12 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "phenotype-cache-adapter"
-version = "0.1.0"
-source = "git+https://github.com/KooshaPari/phenoShared?branch=main#b45ca51dd57ddca5f6aeea138ea7c48cffd69034"
-dependencies = [
- "serde",
- "serde_json",
-]
+version = "0.2.0"
 
 [[package]]
 name = "phenotype-compliance-scanner"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ exclude = [
   # P3 wave 4 — security + macros + async-traits → phenoShared (contracts deferred: API diverge)
   "crates/phenotype-async-traits",
   "crates/phenotype-macros",
-  # Wave 12 — health traits interim phenoShared (PO runtime differs); cache adapter stub interim
+  # Wave 12 — health traits interim phenoShared (PO runtime differs)
   "crates/phenotype-health",
-  "crates/phenotype-cache-adapter",
+  # phenotype-cache-adapter → inline stub at crates/phenotype-cache-adapter-stub (ADR-ECO-014)
   # eco-consolidate — config-loader, mcp
   "crates/phenotype-config-loader",
   "crates/phenotype-mcp",
@@ -140,8 +140,8 @@ phenotype-config-loader = { git = "https://github.com/KooshaPari/phenotype-confi
 phenotype-mcp = { git = "https://github.com/KooshaPari/substrate", branch = "main" }
 # ResilienceKit traits crate (HealthChecker API — PO runtime differs)
 phenotype-health = { git = "https://github.com/KooshaPari/ResilienceKit", branch = "main", package = "phenotype-health" }
-# archive-if-unused stub — retain phenoShared pin until absorbed (wave5b #278 regression fix)
-phenotype-cache-adapter = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+# archive-if-unused stub — inline HexaKit shim; zero phenoShared git deps fleet-wide (ADR-ECO-014)
+phenotype-cache-adapter = { path = "crates/phenotype-cache-adapter-stub" }
 phenotype-contract-adapters = { path = "crates/phenotype-contract-adapters" }
 # Contracts decompose: slice crates on role owners; generic Contract → phenotype-rust-sdk
 phenotype-auth-contracts = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-auth-contracts" }

--- a/crates/phenotype-cache-adapter-stub/Cargo.toml
+++ b/crates/phenotype-cache-adapter-stub/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "phenotype-cache-adapter"
+version = "0.2.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+rust-version = "1.75"
+repository = "https://github.com/KooshaPari/HexaKit"
+authors = ["kooshapari"]
+description = "Archive-if-unused cache adapter stub (ADR-ECO-014). API-compatible placeholder; terminal owner TBD."
+publish = false
+
+[dependencies]

--- a/crates/phenotype-cache-adapter-stub/src/lib.rs
+++ b/crates/phenotype-cache-adapter-stub/src/lib.rs
@@ -1,0 +1,20 @@
+//! Phenotype Cache Adapter — HexaKit inline stub (ADR-ECO-014).
+//!
+//! phenoShared interim pin drained 2026-06-19. Retains `CacheAdapter` placeholder for
+//! `phenotype-core::cache` re-exports until a terminal owner absorbs or completes the impl.
+
+/// Placeholder type for cache adapter
+pub struct CacheAdapter;
+
+impl CacheAdapter {
+    /// Create a new cache adapter
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CacheAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/docs/migrations/wave5-phenoshared-pin-drain-2026-06-19.md
+++ b/docs/migrations/wave5-phenoshared-pin-drain-2026-06-19.md
@@ -25,9 +25,15 @@
 | `phenotype-time` | Not on `phenotype-types` or `phenotype-config` `main` |
 | `phenotype-async-traits`, `phenotype-macros` | `phenotype-rust-sdk` repo does not exist |
 | `phenotype-health` | PO `rust/phenotype-health` API diverges (`HealthCheck` vs `HealthChecker`) |
-| `phenotype-cache-adapter` | archive-if-unused stub verdict — retain phenoShared until absorb |
+| `phenotype-cache-adapter` | **Drained** — inline HexaKit stub `crates/phenotype-cache-adapter-stub` (2026-06-19) |
 | `phenotype-contracts` | Generic `Contract` trait — interim until rust-sdk facade |
 | `phenotype-iter`, `phenotype-string`, `phenotype-validation` | Still only on phenoShared `main` |
+
+## Drained (2026-06-19)
+
+| Pin | Replacement |
+|-----|-------------|
+| `phenotype-cache-adapter` | HexaKit path stub `crates/phenotype-cache-adapter-stub` — **zero phenoShared git deps in HexaKit** |
 
 ## Verification
 


### PR DESCRIPTION
## **User description**
## Summary
- Replace the final phenoShared git pin (`phenotype-cache-adapter`) with an inline path stub at `crates/phenotype-cache-adapter-stub`
- Retains `CacheAdapter` API for `phenotype-core::cache` re-exports (archive-if-unused verdict)
- **Zero phenoShared production git deps in HexaKit** after merge (ADR-ECO-014)

## Changes
- New stub crate: `crates/phenotype-cache-adapter-stub` (minimal `CacheAdapter` placeholder)
- `Cargo.toml`: git pin → `{ path = "crates/phenotype-cache-adapter-stub" }`
- Updated `docs/migrations/wave5-phenoshared-pin-drain-2026-06-19.md`

## Test plan
- [x] `cargo check -p phenotype-core` — **passed on Windows** (27.9s)
- [x] `rg 'KooshaPari/phenoShared' Cargo.toml` — **0 matches**

## Blockers (fleet-wide, outside this PR)
Other repos still pin phenoShared: Pyron, PhenoLang, PhenoObservability, phenotype-python-sdk, ObservabilityKit, TestingKit. See phenoShared tombstone PR for full map.

## Optional follow-up
Rename `phenoShared` → `phenoShared-tombstone` via registry PR (not done here).


___

## **CodeAnt-AI Description**
**Replace the last phenoShared cache adapter pin with a local stub**

### What Changed
- `phenotype-cache-adapter` now resolves to a local HexaKit stub instead of the phenoShared git repo
- The new stub keeps the expected `CacheAdapter` placeholder available so existing re-exports still work
- The migration notes now mark this dependency as drained and record the replacement path

### Impact
`✅ Zero phenoShared git deps in HexaKit`
`✅ Fewer dependency fetch failures`
`✅ Clearer migration status for cache adapter ownership`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
