### PR TITLE
chore(obs): L62 adopt pheno-otel::ErrorCounter for HexaKit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,9 @@ phenotype-process = { path = "crates/phenotype-process" }
 phenotype-project-registry = { path = "crates/phenotype-project-registry" }
 phenotype-shared-config = { path = "crates/phenotype-shared-config" }
 
+# pheno-otel L62 metrics substrate (v14 cycle-4 T7)
+pheno-otel = { path = "../pheno-otel" }
+
 # External utilities
 axum = "0.7"
 axum-extra = "0.9"

--- a/crates/phenotype-retry/Cargo.toml
+++ b/crates/phenotype-retry/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+pheno-otel = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/phenotype-retry/src/executor.rs
+++ b/crates/phenotype-retry/src/executor.rs
@@ -83,6 +83,10 @@ where
         if policy.is_timeout_exceeded(start.elapsed()) {
             let error_msg = last_error.unwrap_or_else(|| "timeout exceeded".to_string());
             tracing_error!("Retry timeout exceeded after {} attempts", attempt);
+            pheno_otel::metrics::record_error(
+                "phenotype_retry.execute_with_retry",
+                "timeout_exceeded",
+            );
             return Err(RetryError {
                 attempts: attempt,
                 last_error: error_msg,
@@ -117,6 +121,10 @@ where
                 // Check if we've exhausted our retry attempts
                 if !policy.should_retry(attempt) {
                     tracing_error!("Retry exhausted after {} attempts: {}", attempt, error_msg);
+                    pheno_otel::metrics::record_error(
+                        "phenotype_retry.execute_with_retry",
+                        "attempts_exhausted",
+                    );
                     return Err(RetryError {
                         attempts: attempt + 1,
                         last_error: error_msg,


### PR DESCRIPTION
## **User description**
v14 cycle-4 T7 — L62 (error rate) observability adoption.

Adopts `pheno_otel::metrics::record_error` in
`phenotype_retry::execute_with_retry` on two error paths:
- timeout exceeded: `kind=timeout_exceeded`
- attempts exhausted: `kind=attempts_exhausted`

Adds:
- `pheno-otel = { path = "../pheno-otel" }` to workspace deps
- `pheno-otel.workspace = true` to phenotype-retry
- 5-line `record_error` calls on the two error returns

Refs: v14 cycle-4 T7, ADR-036B, pillar L62 (71-pillar framework).
Buildable: `cargo check -p phenotype-retry` passes locally.


___

## **CodeAnt-AI Description**
Track retry failures when requests time out or run out of attempts

### What Changed
- Retry failures now record an error signal when the overall timeout is reached
- Retry failures now record an error signal when all retry attempts are used up
- The retry outcome for callers stays the same; this change adds failure tracking for those two cases

### Impact
`✅ Clearer retry failure tracking`
`✅ Faster diagnosis of timeout issues`
`✅ Quicker detection of exhausted retries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
