### PR TITLE
feat(T7-v14): phenotype-retry L62 adoption — record_error on timeout + exhausted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1401,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pheno-otel"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "phenotype-async-traits"
@@ -1666,6 +1690,7 @@ dependencies = [
 name = "phenotype-retry"
 version = "0.2.0"
 dependencies = [
+ "pheno-otel",
  "rand 0.8.6",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,9 @@ phenotype-process = { path = "crates/phenotype-process" }
 phenotype-project-registry = { path = "crates/phenotype-project-registry" }
 phenotype-shared-config = { path = "crates/phenotype-shared-config" }
 
+# pheno-otel L62 metrics substrate (v14 cycle-4 T7)
+pheno-otel = { path = "../pheno-otel" }
+
 # External utilities
 axum = "0.7"
 axum-extra = "0.9"

--- a/crates/phenotype-retry/Cargo.toml
+++ b/crates/phenotype-retry/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+pheno-otel = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/phenotype-retry/src/executor.rs
+++ b/crates/phenotype-retry/src/executor.rs
@@ -83,6 +83,10 @@ where
         if policy.is_timeout_exceeded(start.elapsed()) {
             let error_msg = last_error.unwrap_or_else(|| "timeout exceeded".to_string());
             tracing_error!("Retry timeout exceeded after {} attempts", attempt);
+            pheno_otel::metrics::record_error(
+                "phenotype_retry.execute_with_retry",
+                "timeout_exceeded",
+            );
             return Err(RetryError {
                 attempts: attempt,
                 last_error: error_msg,
@@ -117,6 +121,10 @@ where
                 // Check if we've exhausted our retry attempts
                 if !policy.should_retry(attempt) {
                     tracing_error!("Retry exhausted after {} attempts: {}", attempt, error_msg);
+                    pheno_otel::metrics::record_error(
+                        "phenotype_retry.execute_with_retry",
+                        "attempts_exhausted",
+                    );
                     return Err(RetryError {
                         attempts: attempt + 1,
                         last_error: error_msg,


### PR DESCRIPTION
## **User description**
L62 (error rate observability) adoption for v14 cycle-3 T7. Adopts the new `pheno_otel::metrics::record_error` API at the two highest-traffic error sites in HexaKit's `phenotype-retry` executor: timeout_exceeded, attempts_exhausted. Adds `pheno-otel` as HexaKit workspace-level + `phenotype-retry` crate-level path dep. Depends on pheno-otel#52.


___

## **CodeAnt-AI Description**
**Record retry failures when attempts run out or the overall timeout is reached**

### What Changed
- Retry timeouts now record an error event when the retry budget is exceeded.
- Retry failures now record an error event when no more retry attempts are allowed.
- The retry crate now includes the shared error metrics dependency needed for this reporting.

### Impact
`✅ Clearer retry failure tracking`
`✅ More complete timeout and exhaustion monitoring`
`✅ Faster detection of repeated retry failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
