### PR TITLE
chore(audit): v37 overhaul — fix build, implement resilience crates, expand CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,3 +8,28 @@
 # Security-sensitive
 /SECURITY.md @KooshaPari
 /.github/dependabot.yml @KooshaPari
+
+# Resilience crates (retry, rate-limit)
+/crates/phenotype-retry/ @KooshaPari
+/crates/phenotype-rate-limit/ @KooshaPari
+
+# Routing plane
+/crates/phenotype-router/ @KooshaPari
+
+# Observability stubs (canonical in PhenoObservability)
+/crates/phenotype-telemetry/ @KooshaPari
+/crates/phenotype-health/ @KooshaPari
+
+# Core shared crates
+/crates/phenotype-core/ @KooshaPari
+/crates/phenotype-port-traits/ @KooshaPari
+/crates/phenotype-ports-canonical/ @KooshaPari
+/crates/phenotype-shared-config/ @KooshaPari
+/crates/phenotype-infrastructure/ @KooshaPari
+
+# Compliance / error tooling
+/crates/phenotype-compliance-scanner/ @KooshaPari
+/crates/phenotype-error-macros/ @KooshaPari
+
+# CLI
+/crates/hexakit-cli/ @KooshaPari

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ members = [
   "crates/phenotype-core",
   "crates/phenotype-infrastructure",
   "crates/phenotype-project-registry",
-  "crates/phenotype-security-aggregator",
+  # phenotype-security-aggregator: excluded (incomplete stub; deps missing — tracked in exclude list above)
   "crates/phenotype-xdd-lib",
   "forgecode-fork",
   "crates/phenotype-cache-adapter",
@@ -181,9 +181,6 @@ phenotype-ports-canonical = { path = "crates/phenotype-ports-canonical" }
 phenotype-process = { path = "crates/phenotype-process" }
 phenotype-project-registry = { path = "crates/phenotype-project-registry" }
 phenotype-shared-config = { path = "crates/phenotype-shared-config" }
-
-# pheno-otel L62 metrics substrate (v14 cycle-4 T7)
-pheno-otel = { path = "../pheno-otel" }
 
 # External utilities
 axum = "0.7"

--- a/crates/phenotype-cache-adapter/src/lib.rs
+++ b/crates/phenotype-cache-adapter/src/lib.rs
@@ -1,11 +1,28 @@
 //! phenotype-cache-adapter
 //!
-//! Two-tier cache with L1 (LRU) and L2 (Moka).
+//! Two-tier cache with L1 (LRU) and L2 (Moka), plus the `CacheAdapter` trait
+//! that consuming crates (e.g. `phenotype-core`) re-export.
 
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// Generic cache port trait.  Implement this on any backing store that should
+/// be swappable without changing callsite code.
+pub trait CacheAdapter: Send + Sync {
+    type Key: Clone + Eq + std::hash::Hash + Send + Sync + Debug + 'static;
+    type Value: Clone + Send + Sync + Debug + 'static;
+
+    /// Retrieve a value by key.  Returns `None` on a miss.
+    fn get(&self, key: &Self::Key) -> Option<Self::Value>;
+
+    /// Insert or replace a value.
+    fn put(&self, key: Self::Key, value: Self::Value);
+
+    /// Remove a key, returning the previous value if it existed.
+    fn remove(&self, key: &Self::Key) -> Option<Self::Value>;
+}
 
 /// Metrics hook for observability.
 pub trait MetricsHook: Send + Sync + Debug {

--- a/crates/phenotype-rate-limit/src/lib.rs
+++ b/crates/phenotype-rate-limit/src/lib.rs
@@ -1,11 +1,171 @@
-//! phenotype-rate-limit
+//! phenotype-rate-limit — token-bucket rate limiter.
+//!
+//! A thread-safe token-bucket implementation with configurable capacity and
+//! refill rate. Designed for per-account or per-key quota enforcement in the
+//! routing plane.
 
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 
+/// Errors from the rate-limit subsystem.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("{0}")]
-    Invalid(String),
+    /// The requested token count exceeds the bucket capacity.
+    #[error("requested {requested} tokens exceeds bucket capacity {capacity}")]
+    ExceedsCapacity { requested: u64, capacity: u64 },
+    /// Rate limit exhausted; caller should wait `retry_after`.
+    #[error("rate limit exhausted; retry after {retry_after:?}")]
+    RateLimited { retry_after: Duration },
+    /// Configuration error (e.g. zero capacity or zero refill rate).
+    #[error("invalid rate-limit config: {0}")]
+    InvalidConfig(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Inner state of the token bucket (lock-protected).
+#[derive(Debug)]
+struct BucketState {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+/// A thread-safe token-bucket rate limiter.
+///
+/// Tokens refill continuously at `refill_rate` tokens/second up to `capacity`.
+#[derive(Debug, Clone)]
+pub struct TokenBucket {
+    /// Maximum token count.
+    capacity: f64,
+    /// Token refill rate in tokens per second.
+    refill_rate: f64,
+    state: Arc<Mutex<BucketState>>,
+}
+
+impl TokenBucket {
+    /// Create a new bucket with the given capacity and refill rate (tokens/sec).
+    pub fn new(capacity: u64, refill_rate: f64) -> std::result::Result<Self, Error> {
+        if capacity == 0 {
+            return Err(Error::InvalidConfig("capacity must be > 0".into()));
+        }
+        if refill_rate <= 0.0 {
+            return Err(Error::InvalidConfig("refill_rate must be > 0".into()));
+        }
+        Ok(Self {
+            capacity: capacity as f64,
+            refill_rate,
+            state: Arc::new(Mutex::new(BucketState {
+                tokens: capacity as f64,
+                last_refill: Instant::now(),
+            })),
+        })
+    }
+
+    /// Refill tokens based on elapsed time (called before every check/consume).
+    fn refill(state: &mut BucketState, capacity: f64, refill_rate: f64) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(state.last_refill).as_secs_f64();
+        state.tokens = (state.tokens + elapsed * refill_rate).min(capacity);
+        state.last_refill = now;
+    }
+
+    /// Try to consume `tokens` from the bucket.
+    ///
+    /// Returns `Ok(())` if tokens were available, or `Err(RateLimited { retry_after })`.
+    pub fn try_consume(&self, tokens: u64) -> Result<()> {
+        if tokens as f64 > self.capacity {
+            return Err(Error::ExceedsCapacity {
+                requested: tokens,
+                capacity: self.capacity as u64,
+            });
+        }
+        let mut state = self.state.lock().unwrap();
+        Self::refill(&mut state, self.capacity, self.refill_rate);
+        if state.tokens >= tokens as f64 {
+            state.tokens -= tokens as f64;
+            Ok(())
+        } else {
+            let deficit = tokens as f64 - state.tokens;
+            let wait_secs = deficit / self.refill_rate;
+            Err(Error::RateLimited {
+                retry_after: Duration::from_secs_f64(wait_secs),
+            })
+        }
+    }
+
+    /// Peek at the current available tokens without consuming any.
+    pub fn available(&self) -> f64 {
+        let mut state = self.state.lock().unwrap();
+        Self::refill(&mut state, self.capacity, self.refill_rate);
+        state.tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consume_within_capacity_succeeds() {
+        let bucket = TokenBucket::new(10, 1.0).unwrap();
+        assert!(bucket.try_consume(5).is_ok());
+        assert!(bucket.try_consume(5).is_ok());
+    }
+
+    #[test]
+    fn consume_over_available_fails_with_retry_after() {
+        let bucket = TokenBucket::new(5, 1.0).unwrap();
+        bucket.try_consume(5).unwrap();
+        let err = bucket.try_consume(1).unwrap_err();
+        match err {
+            Error::RateLimited { retry_after } => {
+                // Should wait approximately 1 second for 1 token at 1/s rate.
+                assert!(retry_after >= Duration::from_millis(900));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn exceeds_capacity_is_rejected() {
+        let bucket = TokenBucket::new(5, 10.0).unwrap();
+        let err = bucket.try_consume(10).unwrap_err();
+        assert!(matches!(err, Error::ExceedsCapacity { .. }));
+    }
+
+    #[test]
+    fn invalid_config_zero_capacity() {
+        assert!(TokenBucket::new(0, 1.0).is_err());
+    }
+
+    #[test]
+    fn invalid_config_zero_rate() {
+        assert!(TokenBucket::new(10, 0.0).is_err());
+    }
+
+    #[test]
+    fn available_starts_at_capacity() {
+        let bucket = TokenBucket::new(100, 10.0).unwrap();
+        assert!((bucket.available() - 100.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn refill_over_time() {
+        let bucket = TokenBucket::new(10, 1000.0).unwrap(); // very fast refill
+        bucket.try_consume(10).unwrap();
+        // Sleep a tiny bit — at 1000 tokens/sec, 2ms ≈ 2 tokens.
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(bucket.try_consume(1).is_ok(), "should have refilled by now");
+    }
+
+    #[test]
+    fn bucket_is_clone_and_shared() {
+        let b1 = TokenBucket::new(10, 1.0).unwrap();
+        let b2 = b1.clone();
+        b1.try_consume(5).unwrap();
+        // Both handles share state.
+        let err = b2.try_consume(10).unwrap_err();
+        assert!(matches!(err, Error::RateLimited { .. }));
+    }
+}

--- a/crates/phenotype-retry/Cargo.toml
+++ b/crates/phenotype-retry/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-pheno-otel = { workspace = true }
+tokio = { version = "1", features = ["time"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/phenotype-retry/src/lib.rs
+++ b/crates/phenotype-retry/src/lib.rs
@@ -1,11 +1,205 @@
-//! phenotype-retry
+//! phenotype-retry — exponential-backoff retry primitives.
+//!
+//! Provides synchronous retry with jittered exponential backoff and
+//! configurable per-attempt predicates.
 
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use thiserror::Error;
 
+/// Errors produced by the retry machinery.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("{0}")]
-    Invalid(String),
+    /// All attempts exhausted; carries the last underlying error message.
+    #[error("all {attempts} retry attempts exhausted: {last_error}")]
+    Exhausted {
+        attempts: u32,
+        last_error: String,
+    },
+    /// Policy configuration is invalid (e.g. zero attempts).
+    #[error("invalid retry policy: {0}")]
+    InvalidPolicy(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Backoff strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackoffStrategy {
+    /// Fixed delay between each attempt.
+    Fixed,
+    /// Exponential backoff: `base * 2^attempt`.
+    Exponential,
+    /// Exponential backoff with full jitter (uniform in [0, base * 2^attempt]).
+    ExponentialJitter,
+}
+
+impl Default for BackoffStrategy {
+    fn default() -> Self {
+        Self::ExponentialJitter
+    }
+}
+
+/// Configuration for a retry policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryPolicy {
+    /// Maximum number of attempts (including the first try).
+    pub max_attempts: u32,
+    /// Base delay for backoff computation.
+    pub base_delay: Duration,
+    /// Maximum delay cap; backoff is clamped to this.
+    pub max_delay: Duration,
+    /// Backoff strategy.
+    pub strategy: BackoffStrategy,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(30),
+            strategy: BackoffStrategy::ExponentialJitter,
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Build a policy with the given maximum attempts and default backoff.
+    pub fn with_attempts(max_attempts: u32) -> std::result::Result<Self, Error> {
+        if max_attempts == 0 {
+            return Err(Error::InvalidPolicy("max_attempts must be >= 1".into()));
+        }
+        Ok(Self {
+            max_attempts,
+            ..Default::default()
+        })
+    }
+
+    /// Compute the delay before the `attempt`-th retry (0-indexed; first retry = 1).
+    pub fn delay_for(&self, attempt: u32) -> Duration {
+        let base_ms = self.base_delay.as_millis() as u64;
+        let raw_ms: u64 = match self.strategy {
+            BackoffStrategy::Fixed => base_ms,
+            BackoffStrategy::Exponential => base_ms.saturating_mul(1u64 << attempt.min(62)),
+            BackoffStrategy::ExponentialJitter => {
+                let ceiling = base_ms.saturating_mul(1u64 << attempt.min(62));
+                rand::thread_rng().gen_range(0..=ceiling)
+            }
+        };
+        Duration::from_millis(raw_ms.min(self.max_delay.as_millis() as u64))
+    }
+
+    /// Retry a synchronous fallible closure according to this policy.
+    ///
+    /// `f` receives the current attempt index (0-based) and returns `Ok` or
+    /// `Err(msg)` where `msg` is recorded on final exhaustion.
+    pub fn retry_sync<F, T>(&self, mut f: F) -> Result<T>
+    where
+        F: FnMut(u32) -> std::result::Result<T, String>,
+    {
+        let mut last_error = String::new();
+        for attempt in 0..self.max_attempts {
+            match f(attempt) {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    last_error = e;
+                    if attempt + 1 < self.max_attempts {
+                        std::thread::sleep(self.delay_for(attempt));
+                    }
+                }
+            }
+        }
+        Err(Error::Exhausted {
+            attempts: self.max_attempts,
+            last_error,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn succeeds_on_first_attempt() {
+        let policy = RetryPolicy::with_attempts(3).unwrap();
+        let result = policy.retry_sync(|_| Ok::<_, String>(42));
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn retries_and_succeeds() {
+        let policy = RetryPolicy {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+            strategy: BackoffStrategy::Fixed,
+        };
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+        let result = policy.retry_sync(|_| {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                Err("not yet".to_string())
+            } else {
+                Ok(n)
+            }
+        });
+        assert_eq!(result.unwrap(), 2);
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn exhausts_and_returns_error() {
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(5),
+            strategy: BackoffStrategy::Fixed,
+        };
+        let err = policy
+            .retry_sync(|_| Err::<(), _>("fail".to_string()))
+            .unwrap_err();
+        match err {
+            Error::Exhausted { attempts, .. } => assert_eq!(attempts, 2),
+            _ => panic!("unexpected error variant"),
+        }
+    }
+
+    #[test]
+    fn invalid_policy_zero_attempts() {
+        assert!(RetryPolicy::with_attempts(0).is_err());
+    }
+
+    #[test]
+    fn delay_for_exponential_capped_by_max_delay() {
+        let policy = RetryPolicy {
+            max_attempts: 5,
+            base_delay: Duration::from_millis(100),
+            max_delay: Duration::from_millis(500),
+            strategy: BackoffStrategy::Exponential,
+        };
+        // At high attempt indices the uncapped value would exceed max_delay.
+        let d = policy.delay_for(10);
+        assert!(d <= Duration::from_millis(500));
+    }
+
+    #[test]
+    fn delay_for_jitter_within_bounds() {
+        let policy = RetryPolicy {
+            max_attempts: 5,
+            base_delay: Duration::from_millis(50),
+            max_delay: Duration::from_millis(1000),
+            strategy: BackoffStrategy::ExponentialJitter,
+        };
+        for attempt in 0..5 {
+            let d = policy.delay_for(attempt);
+            assert!(d <= Duration::from_millis(1000));
+        }
+    }
+}

--- a/crates/phenotype-router/Cargo.toml
+++ b/crates/phenotype-router/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 phenotype-port-traits = { workspace = true }
+phenotype-rate-limit = { workspace = true }
 async-stream = { workspace = true }
 axum = { workspace = true }
 bytes = { workspace = true }

--- a/crates/phenotype-router/src/rate_limit.rs
+++ b/crates/phenotype-router/src/rate_limit.rs
@@ -1,17 +1,54 @@
-//! Rate limiting placeholder.
+//! Per-account token-bucket rate limiter for the routing plane.
 //!
-//! TODO(H14.x): implement per-account token-bucket once routing-plane quota
-//! semantics are finalised. Stub keeps `lib.rs`'s `pub mod rate_limit;`
-//! resolvable.
+//! Delegates to `phenotype-rate-limit::TokenBucket`.  Each account key gets
+//! its own bucket; the defaults (100 tokens, 10 tokens/sec) match OmniRoute's
+//! standard per-account quota and can be overridden at construction time.
 
-#[derive(Debug, Clone, Copy, Default)]
+pub use phenotype_rate_limit::{Error, Result, TokenBucket};
+
+/// Default token-bucket capacity for a routing-plane account.
+pub const DEFAULT_CAPACITY: u64 = 100;
+/// Default refill rate (tokens per second) for a routing-plane account.
+pub const DEFAULT_REFILL_RATE: f64 = 10.0;
+
+/// A rate limiter for a single routing-plane account.
+#[derive(Debug, Clone)]
 pub struct RateLimiter {
-    _private: (),
+    bucket: TokenBucket,
 }
 
 impl RateLimiter {
+    /// Create with default capacity and refill rate.
     pub fn new() -> Self {
-        Self { _private: () }
+        Self {
+            // Capacity and rate are hardcoded defaults; infallible.
+            bucket: TokenBucket::new(DEFAULT_CAPACITY, DEFAULT_REFILL_RATE)
+                .expect("default config is always valid"),
+        }
+    }
+
+    /// Create with explicit capacity (tokens) and refill rate (tokens/sec).
+    pub fn with_quota(capacity: u64, refill_rate: f64) -> Result<Self> {
+        Ok(Self {
+            bucket: TokenBucket::new(capacity, refill_rate)?,
+        })
+    }
+
+    /// Attempt to consume `tokens` for this request.  Returns `Ok(())` if
+    /// allowed or `Err(RateLimited { retry_after })` if the bucket is empty.
+    pub fn try_consume(&self, tokens: u64) -> Result<()> {
+        self.bucket.try_consume(tokens)
+    }
+
+    /// Available tokens at this instant (informational; not authoritative).
+    pub fn available(&self) -> f64 {
+        self.bucket.available()
+    }
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -20,7 +57,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn constructs() {
-        let _ = RateLimiter::new();
+    fn default_constructs_and_allows_requests() {
+        let rl = RateLimiter::new();
+        assert!(rl.try_consume(1).is_ok());
+    }
+
+    #[test]
+    fn with_quota_small_capacity_exhausts() {
+        let rl = RateLimiter::with_quota(2, 1.0).unwrap();
+        rl.try_consume(2).unwrap();
+        assert!(rl.try_consume(1).is_err());
+    }
+
+    #[test]
+    fn available_reports_current_tokens() {
+        let rl = RateLimiter::new();
+        let before = rl.available();
+        rl.try_consume(10).unwrap();
+        let after = rl.available();
+        assert!(before > after, "tokens should decrease after consume");
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

v37 audit scorecard mean 1.57/3. This PR addresses the scorecard's top findings that were fixable without cross-repo migration.

### Fixed

- **Build broken (P0)**: Removed dangling `pheno-otel = { path = "../pheno-otel" }` workspace dep — path never existed; `cargo check --workspace` was completely broken.
- **Build broken (P0)**: Removed `phenotype-security-aggregator` from `members` list (was in both `exclude` AND `members`; explicit `members` wins, causing 18 compile errors from missing `anyhow`/`reqwest` deps). Now correctly excluded.
- **Stub → real: `phenotype-retry`**: Replaced empty `Error`/`Result` stub with a real `RetryPolicy` + `BackoffStrategy` (Fixed / Exponential / ExponentialJitter with full jitter cap), `delay_for()`, and `retry_sync()` with backoff sleep. 6 unit tests.
- **Stub → real: `phenotype-rate-limit`**: Replaced empty stub with a thread-safe token-bucket (`Arc<Mutex<BucketState>>`), configurable capacity + refill rate, `try_consume()` returning `retry_after: Duration` on exhaustion. 8 unit tests.
- **Stub → real: `phenotype-router/src/rate_limit.rs`**: Wired router's private-field `RateLimiter` stub to use `phenotype-rate-limit::TokenBucket` with `DEFAULT_CAPACITY=100` / `DEFAULT_REFILL_RATE=10.0`. Adds `RateLimiter::with_quota()` for per-account overrides. 3 unit tests.
- **Broken re-export (`phenotype-cache-adapter`)**: Added `CacheAdapter` trait so `phenotype-core::cache::CacheAdapter` re-export compiles (was a broken re-export of a non-existent item).
- **CODEOWNERS**: Expanded from 5 global lines to per-crate entries for resilience, routing, observability stubs, core, compliance, and CLI crates.

### Test results

```
test result: ok. 41 passed; 0 failed; 0 ignored (phenotype-retry + phenotype-rate-limit + phenotype-router)
cargo check --workspace: Finished (no errors)
```

## NOT done (honest list)

| Finding | Reason not done |
|---|---|
| OTel `/healthz` + `/metrics` mounting | Crates migrated to PhenoObservability; HexaKit stubs are redirect stubs only |
| `criterion` perf benchmarks | Harness not yet wired; separate PR scope |
| `crates.io` publish | `publish = false` on root; needs token setup + `publish = true` per crate |
| `Dependabot` 25 advisories (4 high) | Dep bump wave; separate PR |

## Cross-project reuse note (L35 — ResilienceKit consolidation)

The v37 meta-retro flagged overlap between HexaKit's `phenotype-retry` / `phenotype-rate-limit` and `ResilienceKit`'s scope. **This PR implements the stubs as real crates** (making them useful now), but the org-level decision of whether to:
- Promote HexaKit resilience crates as the org SSOT and deprecate ResilienceKit equivalents, or
- Migrate HexaKit callers to ResilienceKit and prune these crates

...is documented here but **not executed unilaterally** per instructions. Recommend a follow-up spec in AgilePlus to resolve the SSOT question.


___

## **CodeAnt-AI Description**
**Restore build stability and add working retry/rate-limit behavior**

### What Changed
- Fixed the workspace so the project builds again by removing broken references to missing crates and correcting the workspace crate list
- Replaced placeholder retry code with a real retry policy that supports fixed, exponential, and jittered backoff, plus synchronous retries with delays between attempts
- Replaced placeholder rate limiting with a working token-bucket limiter that enforces per-account quotas and tells callers when they can try again
- Wired the router to use the real shared rate limiter instead of a stub, with default limits and optional custom quotas
- Added the missing cache adapter interface so shared cache re-exports compile correctly
- Expanded CODEOWNERS so key crates route to the right owner areas

### Impact
`✅ Fewer build failures`
`✅ Clearer retry handling after temporary errors`
`✅ Enforced per-account request limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
