### PR TITLE
feat(core): migrate Eventra runtime boundary to phenoEvents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.75"
+rust-version = "1.94"
 repository = "https://github.com/KooshaPari/HexaKit"
 description = "Phenotype Infrastructure Kit"
 authors = ["kooshapari"]
@@ -20,8 +20,7 @@ exclude = [
   # P3 wave 1 — error crates canonical in phenoShared (API-compatible)
   "crates/phenotype-error-core",
   "crates/phenotype-errors",
-  # P3 wave 2 — event crates interim phenoShared (Eventra absorb pending); http-client → ResilienceKit
-  "crates/phenotype-event-bus",
+  # P3 wave 2 — http-client → ResilienceKit
   "crates/phenotype-http-client-core",
   # P3 wave 3 — logging → PO; time now local in HexaKit; state-machine + policy → ResilienceKit
   "crates/phenotype-logging",
@@ -131,8 +130,8 @@ arc-swap = "1"
 # phenoShared interim pins drained wave 5b (ADR-ECO-014) — terminal DOMAIN_ROLES owners
 phenotype-error-core = { git = "https://github.com/KooshaPari/phenotype-types", branch = "main" }
 phenotype-errors = { git = "https://github.com/KooshaPari/phenotype-types", branch = "main" }
-# Eventra terminal owner (wave 5b)
-phenotype-event-bus = { git = "https://github.com/KooshaPari/Eventra", branch = "main", package = "phenotype-event-bus" }
+# Canonical event runtime; Eventra was archived after this migration.
+pheno-events = { git = "https://github.com/KooshaPari/phenoEvents", tag = "v0.1.0" }
 phenotype-event-sourcing = { path = "crates/phenotype-event-sourcing" }
 # ResilienceKit = phenotype-resilience DOMAIN_ROLES owner
 phenotype-http-client-core = { git = "https://github.com/KooshaPari/ResilienceKit", branch = "main" }
@@ -154,7 +153,6 @@ phenotype-cache-adapter = { path = "crates/phenotype-cache-adapter" }
 phenotype-contract-adapters = { path = "crates/phenotype-contract-adapters" }
 # Contracts decompose: slice crates on role owners; generic Contract → phenotype-rust-sdk
 phenotype-auth-contracts = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-auth-contracts" }
-phenotype-event-contracts = { git = "https://github.com/KooshaPari/Eventra", branch = "main", package = "phenotype-event-contracts" }
 phenotype-agent-contracts = { git = "https://github.com/KooshaPari/Agentora", branch = "main", package = "phenotype-agent-contracts" }
 phenotype-contracts = { git = "https://github.com/KooshaPari/phenotype-rust-sdk", branch = "main" }
 phenotype-security-aggregator = { git = "https://github.com/KooshaPari/Authvault", branch = "main", package = "phenotype-security-aggregator" }

--- a/crates/phenotype-core/Cargo.toml
+++ b/crates/phenotype-core/Cargo.toml
@@ -16,7 +16,8 @@ tokio = { workspace = true }
 phenotype-error-core = { workspace = true }
 phenotype-errors = { workspace = true }
 phenotype-config-core = { workspace = true }
-phenotype-event-bus = { workspace = true }
+pheno-events = { workspace = true }
+uuid = { workspace = true }
 phenotype-validation = { workspace = true }
 phenotype-health = { workspace = true }
 phenotype-telemetry = { workspace = true }

--- a/crates/phenotype-core/README.md
+++ b/crates/phenotype-core/README.md
@@ -24,9 +24,9 @@ phenotype-core = { workspace = true }
 - `phenotype_config_core::Priority`
 
 ### Event Bus
-- `phenotype_event_bus::EventBus`
-- `phenotype_event_bus::EventEnvelope`
-- `phenotype_event_bus::EventId` (ULID-based)
+- `pheno_events::bus::Bus` (re-exported as `phenotype_core::event_bus::EventBus`)
+- `pheno_events::core::EventEnvelope`
+- `phenotype_core::event_bus::EventId` (UUIDv7)
 
 ### Validation
 - `phenotype_validation::ValidationRule`

--- a/crates/phenotype-core/src/lib.rs
+++ b/crates/phenotype-core/src/lib.rs
@@ -81,9 +81,18 @@ pub mod config {
     };
 }
 
-/// Event bus re-exports
+/// Event bus re-exports from the canonical phenoEvents runtime.
 pub mod event_bus {
-    pub use phenotype_event_bus::{EventBus, EventBusError, EventEnvelope, EventId, Subscription};
+    pub use pheno_events::{
+        bus::{Ack, Bus, Handler, HandlerError, PublishError, SubscribeError, Subscription},
+        core::{EnvelopeError, EventEnvelope},
+    };
+
+    /// Backward-compatible name for the canonical [`Bus`] trait.
+    pub use Bus as EventBus;
+
+    /// Stable event identifier used by phenoEvents envelopes.
+    pub type EventId = uuid::Uuid;
 }
 
 /// Validation re-exports

--- a/crates/phenotype-core/src/lib.rs
+++ b/crates/phenotype-core/src/lib.rs
@@ -83,11 +83,10 @@ pub mod config {
 
 /// Event bus re-exports from the canonical phenoEvents runtime.
 pub mod event_bus {
-    pub use pheno_events::{
-        bus::{Ack, Bus, Handler, HandlerError, PublishError, SubscribeError, Subscription},
-        core::{EnvelopeError, EventEnvelope},
+    pub use pheno_events::bus::{
+        Ack, Bus, Handler, HandlerError, PublishError, SubscribeError, Subscription,
     };
-
+    pub use pheno_events::core::{EnvelopeError, EventEnvelope};
     /// Backward-compatible name for the canonical [`Bus`] trait.
     pub use Bus as EventBus;
 


### PR DESCRIPTION
## **User description**
Closes #322\n\n## Changes\n- replace the archived Eventra phenotype-event-bus workspace dependency with canonical pheno-events v0.1.0\n- preserve phenotype_core::event_bus::EventBus and EventId aliases while re-exporting the maintained canonical bus types\n- remove the unused archived phenotype-event-contracts pin\n- align workspace MSRV with pheno-events v0.1.0 (Rust 1.94)\n\n## Validation\n- cargo test --workspace in a clean checkout of phenoEvents tag 0.1.0: 46 passed\n- HexaKit cargo check -p phenotype-core is currently blocked before resolution by the existing unreachable KooshaPari/phenotype-types Git revision dd14f735; this is unrelated to this change and prevents a correct lockfile regeneration.\n- git diff --check passes.


___

## **CodeAnt-AI Description**
**Move the core event API to the maintained phenoEvents runtime while keeping the old names available**

### What Changed
- The core event bus now uses phenoEvents as the backing runtime instead of the archived Eventra package
- Existing code can still use `phenotype_core::event_bus::EventBus` and `EventId`, but `EventId` now uses UUIDv7 values
- The public event re-exports now include the canonical bus, handler, publish/subscribe, acknowledgment, and envelope types from phenoEvents
- The workspace now depends on the new event runtime and no longer pins the archived event contracts package

### Impact
`✅ Continued event-bus compatibility for existing users`
`✅ Access to the maintained event runtime`
`✅ UUIDv7 event IDs in new envelopes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
